### PR TITLE
ADD Log traces for debugging

### DIFF
--- a/bin/iotaULTester.js
+++ b/bin/iotaULTester.js
@@ -96,6 +96,13 @@ function singleMeasure(commands) {
     mqttClient.publish(topic, commands[1], null, mqttPublishHandler);
 }
 
+function sendCommandResult(commands) {
+    var topic = '/' + config.apikey + '/' + config.deviceId + '/cmdexe',
+        payload = config.deviceId + '@' + commands[0] + '|' + commands[1];
+
+    mqttClient.publish(topic, payload, null, mqttPublishHandler);
+}
+
 function parseMultipleAttributes(attributeString) {
     var result,
         attributes,
@@ -166,14 +173,14 @@ var commands = {
         '\tstring should have the following syntax: name=value[;name=value]*',
         handler: checkConnection(multipleMeasure)
     },
-    'exit': {
-        parameters: [],
-        description: '\tExit the client',
-        handler: exitClient
+    'mqttCommand': {
+        parameters: ['command', 'result'],
+        description: '\tSend the result of a command to the MQTT Broker.',
+        handler: checkConnection(sendCommandResult)
     }
 };
 
-commands = _.extend(commands, commandLine.commands);
+commands = _.extend(commandLine.commands, commands);
 commandLine.init(configCb, configIot);
 
 clUtils.initialize(commands, 'Ultralight 2.0 IoTA tester> ');

--- a/lib/bindings/HTTPBindings.js
+++ b/lib/bindings/HTTPBindings.js
@@ -180,16 +180,8 @@ function updateCommand(apiKey, device, message, callback) {
  */
 function generateCommandExecution(apiKey, device, attribute) {
     var cmdName = attribute.name,
-        cmdAttributes,
+        cmdAttributes = attribute.value,
         options;
-
-    try {
-        cmdAttributes = JSON.parse(attribute.value);
-    } catch (e) {
-        return function(callback) {
-            callback(errors.ParseError(e));
-        };
-    }
 
     options = {
         url: device.endpoint,

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -31,7 +31,6 @@ var iotAgentLib = require('iotagent-node-lib'),
     logger = require('logops'),
     async = require('async'),
     apply = async.apply,
-    errors = require('../errors'),
     constants = require('../constants'),
     context = {
         op: 'IOTAUL.MQTT.Binding'

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -264,6 +264,9 @@ function generateCommandExecution(apiKey, device, attribute) {
 
     payload = ulParser.createCommandPayload(device, cmdName, cmdAttributes);
 
+    logger.debug('Sending command execution to device [%s] with apikey [%s] and payload [%s] ',
+        apiKey, device.id, payload);
+
     return mqttClient.publish.bind(mqttClient, '/' + apiKey + '/' + device.id + '/cmd', payload, null);
 }
 
@@ -277,6 +280,8 @@ function generateCommandExecution(apiKey, device, attribute) {
  * @param {String} attributes       Command attributes (in NGSIv1 format).
  */
 function commandHandler(device, attributes, callback) {
+    logger.debug('Handling MQTT command for device [%s]', device.id);
+
     utils.getEffectiveApiKey(device.service, device.subservice, function(error, apiKey) {
         async.series(attributes.map(generateCommandExecution.bind(null, apiKey, device)), callback);
     });

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -251,16 +251,8 @@ function mqttMessageHandler(topic, message) {
  */
 function generateCommandExecution(apiKey, device, attribute) {
     var cmdName = attribute.name,
-        cmdAttributes,
+        cmdAttributes = attribute.value,
         payload;
-
-    try {
-        cmdAttributes = JSON.parse(attribute.value);
-    } catch (e) {
-        return function(callback) {
-            callback(errors.ParseError(e));
-        };
-    }
 
     payload = ulParser.createCommandPayload(device, cmdName, cmdAttributes);
 

--- a/lib/iotagent-ul.js
+++ b/lib/iotagent-ul.js
@@ -74,11 +74,14 @@ function stopTransportBindings(callback) {
  * @param {String} protocol         Transport protocol where the function must be executed.
  */
 function applyFunctionFromBinding(argument, functionName, protocol, callback) {
+    logger.debug('Looking for bindings for the function [%s] and protocol [%s]', functionName, protocol);
+
     function addHandler(current, binding) {
         if (binding[functionName] && (!protocol || binding.protocol === protocol)) {
             var args = [binding[functionName]].concat(argument),
                 boundFunction = binding[functionName].bind.apply(binding[functionName], args);
 
+            logger.debug('Binding found for function [%s] and protocol [%s]', functionName, protocol);
             current.push(boundFunction);
         }
 
@@ -119,6 +122,8 @@ function configurationHandler(configuration, callback) {
 function commandHandler(id, type, attributes, callback) {
     iotAgentLib.getDeviceByName(id, function(error, device) {
         if (error) {
+            logger.error('Command execution could not be handled, as device for entity [%s] [%s] wasn\'t found',
+                id, type);
             callback(error);
         } else {
             applyFunctionFromBinding([device, attributes], 'commandHandler',

--- a/test/contextRequests/updateCommand1.json
+++ b/test/contextRequests/updateCommand1.json
@@ -9,7 +9,9 @@
         {
           "name": "PING",
           "type": "command",
-          "value": "{\"data\": \"22\"}"
+          "value": {
+            "data": "22"
+          }
         }
       ]
     }


### PR DESCRIPTION
- Add some log traces to aid in debugging the agent.
- Add a `sendMQTTCommand` for the command line interpreter.
- Change the payload of the commands from stringified JSON to plain objects.