### PR TITLE
FIX Different log type in libraries and general logs

### DIFF
--- a/lib/iotagent-ul.js
+++ b/lib/iotagent-ul.js
@@ -155,6 +155,7 @@ function start(newConfig, callback) {
         connectTimeout: 60 * 60 * 1000
     };
 
+    logger.format = logger.formatters.pipe;
     config.setConfig(newConfig);
 
     if (config.getConfig().mqtt.username && config.getConfig().mqtt.password) {


### PR DESCRIPTION
Fix the different log type (JSON or Pipe) for the library and the IOTA log.