### PR TITLE
FIX Provisioning handler raising errors

### DIFF
--- a/lib/iotagent-ul.js
+++ b/lib/iotagent-ul.js
@@ -98,7 +98,13 @@ function applyFunctionFromBinding(argument, functionName, protocol, callback) {
  * @param {Object} device           Device provisioning information.
  */
 function deviceProvisioningHandler(device, callback) {
-    applyFunctionFromBinding([device], 'deviceProvisioningHandler', null, callback);
+    applyFunctionFromBinding([device], 'deviceProvisioningHandler', null, function(error, devices) {
+        if (error) {
+            callback(error);
+        } else {
+            callback(null, devices[0]);
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
HTTP Provisioning handler raised an error, passing an array to the device provisioning handler callback.