### PR TITLE
Using absolute path for npm post requirement

### DIFF
--- a/rpm/SPECS/iotaul.spec
+++ b/rpm/SPECS/iotaul.spec
@@ -7,7 +7,7 @@ BuildRoot: %{_topdir}/BUILDROOT/
 BuildArch: x86_64
 # Requires: nodejs >= 0.10.24
 Requires: logrotate
-Requires(post): /sbin/chkconfig, /usr/sbin/useradd npm
+Requires(post): /sbin/chkconfig, /usr/sbin/useradd /usr/bin/npm
 Requires(preun): /sbin/chkconfig, /sbin/service
 Requires(postun): /sbin/service
 Group: Applications/Engineering


### PR DESCRIPTION
Using npm instead of /usr/bin/npm causes a bad behaviour on rpm installation. This commit fix the requirements in post step