### PR TITLE
Fix parameter order for the MEASURE-001 error message

### DIFF
--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -166,7 +166,7 @@ function retrieveDevice(deviceId, apiKey, transport, callback) {
             } else {
                 config.getLogger().error(context,
                     'MEASURES-001: Couldn\'t find device data for APIKey [%s] and DeviceId[%s]',
-                    deviceId, apiKey);
+                    apiKey, deviceId);
 
                 callback(new errors.DeviceNotFound(deviceId));
             }


### PR DESCRIPTION
Parameters for the MEASURE-001 error are passed using the wrong order in a similar way than in iotagent-json (See telefonicaid/iotagent-json#290)

This small PR fixes this problem.