### PR TITLE
Step: 1.6.0-next -> 1.7.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,7 +1,0 @@
-- Add: unhardwire MQTT qos and retain parameters in config.js (involving new env vars IOTA_MQTT_QOS and IOTA_MQTT_RETAIN) (#255)
-- Remove mongodb dependence from packages.json (already in iota-node-lib)
-- Add: allow NGSIv2 for updating active attributes at CB, throught configuration based on iotagent-node-lib(#233)
-- Fix: parameter order for the MEASURE-001 error message (#264)
-- Using precise dependencies (~=) in packages.json
-- Fix: upgrade mqtt dep from 1.7.0 to 1.14.1
-- Add: supports NGSIv2 for device provisioning (entity creation and context registration) at CB (#233)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-ul",
   "description": "IoT Agent for the Ultrlight 2.0 protocol",
-  "version": "1.6.0-next",
+  "version": "1.7.0",
   "homepage": "https://github.com/telefonicaid/iotagent-ul",
   "author": {
     "name": "Daniel Moran",
@@ -27,7 +27,7 @@
     "body-parser": "1.15.0",
     "dateformat": "1.0.12",
     "express": "~4.11.2",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "2.7.x",
     "logops": "1.0.0-alpha.7",
     "mqtt": "1.14.1",
     "request": "2.81.0",

--- a/rpm/SPECS/iotaul.spec
+++ b/rpm/SPECS/iotaul.spec
@@ -170,6 +170,16 @@ fi
 %{_install_dir}
 
 %changelog
+* Mon Aug 06 2018 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.7.0
+- Update iotagent-node-lib to 2.7.x
+- Add: allow NGSIv2 for updating active attributes at CB, throught configuration based on iotagent-node-lib(#233)
+- Add: supports NGSIv2 for device provisioning (entity creation and context registration) at CB (#233)
+- Add: unhardwire MQTT qos and retain parameters in config.js (involving new env vars IOTA_MQTT_QOS and IOTA_MQTT_RETAIN) (#255)
+- Fix: parameter order for the MEASURE-001 error message (#264)
+- Fix: upgrade mqtt dep from 1.7.0 to 1.14.1
+- Using precise dependencies (~=) in packages.json
+- Remove mongodb dependence from packages.json (already in iota-node-lib)
+
 * Mon Feb 26 2018 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.6.0
 - Update ioagent-node-lib to 2.6.x
 - Fix transport in autoprovision device depending on binding (#235)


### PR DESCRIPTION
Similar to PR https://github.com/telefonicaid/iotagent-ul/pull/247 (except npm-shrinkwrap.json generation, that is no longer include in the repository)