### PR TITLE
Step: 1.7.0 -> 1.7.0-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-ul",
   "description": "IoT Agent for the Ultrlight 2.0 protocol",
-  "version": "1.7.0",
+  "version": "1.7.0-next",
   "homepage": "https://github.com/telefonicaid/iotagent-ul",
   "author": {
     "name": "Daniel Moran",
@@ -27,7 +27,7 @@
     "body-parser": "1.15.0",
     "dateformat": "1.0.12",
     "express": "~4.11.2",
-    "iotagent-node-lib": "2.7.x",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "1.0.0-alpha.7",
     "mqtt": "1.14.1",
     "request": "2.81.0",


### PR DESCRIPTION
Similar to PR https://github.com/telefonicaid/iotagent-ul/pull/248 (except npm-shrinkwrap.json generation, that it is no longer included in repository)