### PR TITLE
Ignore duplicate MQTT message(s) when iotagent-ul in HA

### DIFF
--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -160,9 +160,19 @@ function start(callback) {
         callback(e);
     });
 
-    mqttClient.on('message', commonBindings.messageHandler);
+    // customized by Nobuyuki Matsui
+    // execute mqttExtensions.execute before calling 'commonBindings.messageHandler' when receiving mqtt message
+    // originaru => mqttClient.on('message', commonBindings.messageHandler);
+    if (config.getConfig().mqtt &&
+        config.getConfig().mqtt.extensions &&
+        Array.isArray(config.getConfig().mqtt.extensions)) {
+        var mqttExtensions = require('../extensions/mqtt-extensions');
+        mqttClient.on('message', mqttExtensions.execute(commonBindings.messageHandler));
+    } else {
+        mqttClient.on('message', commonBindings.messageHandler);
+    }
 
-    mqttClient.on('connect', function(ack) {
+    mqttClient.on('connect', function() {
         config.getLogger().info(context, 'MQTT Client connected');
         recreateSubscriptions(callback);
     });

--- a/lib/extensions/mqtt-extensions.js
+++ b/lib/extensions/mqtt-extensions.js
@@ -1,0 +1,47 @@
+'use strict';
+/*
+ * Copyright 2018 Nobuyuki Matsui
+ *
+ * This file is extension of iotagent-ul
+ * call 'extension' REST API when receiving message from mqtt if 'config.mqtt.extensions' is set
+ */
+
+var async = require('async');
+var request = require('request');
+var config = require('../configService');
+
+function execute(callback) {
+    return function(topic, message) {
+        async.eachSeries(config.getConfig().mqtt.extensions, function(extension, next) {
+            if (extension.providerUrl && extension.name) {
+                request.post({
+                    uri: extension.providerUrl,
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    json: {
+                        'payload': topic + '::' + message.toString()
+                    },
+                    timeout: 500
+                }).on('response', function(response) {
+                    if (response.statusCode === 200) {
+                        next(null);
+                    } else {
+                        next(extension.name + ' returned statusCode = ' + String(response.statusCode));
+                    }
+                }).on('error', function(error) {
+                    next(error);
+                });
+            } else {
+                next('invalid config.mqtt.extension');
+            }
+        }, function(error) {
+            if (!error) {
+                callback(topic, message);
+            } else {
+                config.getLogger().info(error);
+            }
+        });
+    };
+}
+exports.execute = execute;

--- a/test/unit/config-dupcheck-test.js
+++ b/test/unit/config-dupcheck-test.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-mqtt
+ *
+ * iotagent-mqtt is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-mqtt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-mqtt.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * copy "config-test" and edit to test duplication message checker by Nobuyuki Matsui<nobuyuki.matsui@gmail.com>
+ */
+var config = {};
+
+config.mqtt = {
+    host: 'localhost',
+    port: 1883,
+    username: 'guest',
+    password: 'guest',
+    extensions: [
+        {
+            name: 'distinctMessage',
+            description: 'distinct mqtt message',
+            providerUrl: 'http://192.168.1.2:5000/distinct/'
+        }
+    ]
+};
+
+config.http = {
+    port: 7896
+};
+
+config.amqp = {
+    port: 5672,
+    exchange: 'amq.topic',
+    queue: 'iota_queue',
+    options: {durable: true}
+};
+
+config.iota = {
+    logLevel: 'FATAL',
+    contextBroker: {
+        host: '192.168.1.1',
+        port: '1026'
+    },
+    server: {
+        port: 4041
+    },
+    deviceRegistry: {
+        type: 'memory'
+    },
+    types: {},
+    service: 'howtoService',
+    subservice: '/howto',
+    providerUrl: 'http://localhost:4041',
+    deviceRegistrationDuration: 'P1M',
+    defaultType: 'Thing',
+    defaultResource: '/iot/d'
+};
+
+config.defaultKey = '1234';
+config.defaultTransport = 'MQTT';
+
+module.exports = config;

--- a/test/unit/mqttBinding-dupcheck-test.js
+++ b/test/unit/mqttBinding-dupcheck-test.js
@@ -1,0 +1,576 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ *
+ * copy "mqttBinding-test" and edit to test duplication message checker by Nobuyuki Matsui<nobuyuki.matsui@gmail.com>
+ */
+
+'use strict';
+
+var iotagentMqtt = require('../../'),
+    mqtt = require('mqtt'),
+    config = require('./config-dupcheck-test.js'),
+    nock = require('nock'),
+    iotAgentLib = require('iotagent-node-lib'),
+    async = require('async'),
+    request = require('request'),
+    utils = require('../utils'),
+    contextBrokerMock,
+    dupCheckerMock,
+    mqttClient;
+
+describe('MQTT Transport binding with duplication checker: measures', function() {
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionDevice1.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        nock.cleanAll();
+
+        mqttClient = mqtt.connect('mqtt://' + config.mqtt.host, {
+            keepalive: 0,
+            connectTimeout: 60 * 60 * 1000
+        });
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v1/updateContext')
+            .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+        dupCheckerMock = nock('http://192.168.1.2:5000')
+            .post('/distinct/')
+            .reply(200, {result: 'success'});
+
+        iotagentMqtt.start(config, function() {
+            request(provisionOptions, function(error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+        mqttClient.end();
+
+        async.series([
+            iotAgentLib.clearAll,
+            iotagentMqtt.stop
+        ], done);
+    });
+
+    describe('When a new non-duplicated single measure arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a new update context request to the Context Broker with just that attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs/a', '23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated single measure arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a new update context request to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs/a', '23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated measure arrives for an unprovisioned Device', function() {
+        var groupCreation = {
+                url: 'http://localhost:4041/iot/services',
+                method: 'POST',
+                json: utils.readExampleFile('./test/groupProvisioning/provisionFullGroup.json'),
+                headers: {
+                    'fiware-service': 'TestService',
+                    'fiware-servicepath': '/testingPath'
+                }
+            };
+
+        beforeEach(function(done) {
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v1/updateContext')
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/unprovisionedMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/unprovisionedSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+
+            request(groupCreation, function(error, response, body) {
+                done();
+            });
+        });
+
+        it('should send a new update context request to the Context Broker with just that attribute', function(done) {
+            mqttClient.publish('/80K09H324HV8732/MQTT_UNPROVISIONED/attrs/a', '23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated measure arrives for an unprovisioned Device', function() {
+        var groupCreation = {
+                url: 'http://localhost:4041/iot/services',
+                method: 'POST',
+                json: utils.readExampleFile('./test/groupProvisioning/provisionFullGroup.json'),
+                headers: {
+                    'fiware-service': 'TestService',
+                    'fiware-servicepath': '/testingPath'
+                }
+            };
+
+        beforeEach(function(done) {
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v1/updateContext')
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/unprovisionedMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/unprovisionedSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+
+            request(groupCreation, function(error, response, body) {
+                done();
+            });
+        });
+
+        it('should not send a new update context request to the Context Broker', function(done) {
+            mqttClient.publish('/80K09H324HV8732/MQTT_UNPROVISIONED/attrs/a', '23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated multiple measure arrives to a Device topic with one measure', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a single update context request with all the attributes', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated multiple measure arrives to a Device topic with one measure', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a single update context request with all the attributes', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated multiple measure arrives to a Device topic with a faulty payload', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should silently ignore the error (without crashing)', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'notAULPayload ', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated multiple measure arrives to a Device topic with a faulty payload', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should silently ignore the error (without crashing)', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'notAULPayload ', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When non-duplicated single message with multiple measures arrive to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/multipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send one update context per measure group to the Contet Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23|b|98', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When duplicated single message with multiple measures arrive to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/multipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send one update context per measure group to the Contet Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23|b|98', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a non-duplicated message with multiple measure groups arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/secondSingleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/secondSingleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a two update context requests to the Context Broker one with each attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23#b|98', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a duplicated message with multiple measure groups arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/singleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/singleMeasureSuccess.json'));
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/secondSingleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/secondSingleMeasureSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a update context requests to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23#b|98', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When non-duplicated multiple groups of measures arrive, with multiple attributes, to a Device topic',
+        function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/multipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/secondMultipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a two update context requests to the Context Broker one with each attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23|b|98#a|16|b|34', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When duplicated multiple groups of measures arrive, with multiple attributes, to a Device topic',
+        function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/multipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/secondMultipleMeasure.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/multipleMeasuresSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a two update context requests to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'a|23|b|98#a|16|b|34', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a non-duplicated measure with a timestamp arrives with an alias to TimeInstant', function() {
+        var provisionProduction = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'POST',
+                json: utils.readExampleFile('./test/deviceProvisioning/provisionTimeInstant.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+        beforeEach(function(done) {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext')
+                .reply(200, utils.readExampleFile('./test/contextResponses/timeInstantDuplicatedSuccess.json'))
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/timeInstantDuplicated.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/timeInstantDuplicatedSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+
+            config.iota.timestamp = true;
+
+            nock('http://localhost:8082')
+                .post('/protocols')
+                .reply(200, {});
+
+            iotagentMqtt.stop(function() {
+                iotagentMqtt.start(config, function(error) {
+                    request(provisionProduction, function(error, response, body) {
+                        done();
+                    });
+                });
+            });
+        });
+
+        afterEach(function() {
+            config.iota.timestamp = false;
+        });
+
+        it('should use the provided TimeInstant as the general timestamp for the measures', function(done) {
+            mqttClient.publish(
+                '/1234/timestampedDevice/attrs',
+                'tmp|24.4|tt|2016-09-26T12:19:26.476659Z', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a duplicated measure with a timestamp arrives with an alias to TimeInstant', function() {
+        var provisionProduction = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'POST',
+                json: utils.readExampleFile('./test/deviceProvisioning/provisionTimeInstant.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+        beforeEach(function(done) {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v1/updateContext')
+                .reply(200, utils.readExampleFile('./test/contextResponses/timeInstantDuplicatedSuccess.json'))
+                .post('/v1/updateContext', utils.readExampleFile('./test/contextRequests/timeInstantDuplicated.json'))
+                .reply(200, utils.readExampleFile('./test/contextResponses/timeInstantDuplicatedSuccess.json'));
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+
+            config.iota.timestamp = true;
+
+            nock('http://localhost:8082')
+                .post('/protocols')
+                .reply(200, {});
+
+            iotagentMqtt.stop(function() {
+                iotagentMqtt.start(config, function(error) {
+                    request(provisionProduction, function(error, response, body) {
+                        done();
+                    });
+                });
+            });
+        });
+
+        afterEach(function() {
+            config.iota.timestamp = false;
+        });
+
+        it('should not send a update context request to the Context Broker', function(done) {
+            mqttClient.publish(
+                '/1234/timestampedDevice/attrs',
+                'tmp|24.4|tt|2016-09-26T12:19:26.476659Z', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/config-dupcheck-test.js
+++ b/test/unit/ngsiv2/config-dupcheck-test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-mqtt
+ *
+ * iotagent-mqtt is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-mqtt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-mqtt.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Fernando Méndez, Daniel Calvo - ATOS Research & Innovation
+ *
+ * copy "config-test" and edit to test duplication message checker by Nobuyuki Matsui<nobuyuki.matsui@gmail.com>
+ */
+var config = {};
+
+config.mqtt = {
+    host: 'localhost',
+    port: 1883,
+    username: 'guest',
+    password: 'guest',
+    extensions: [
+        {
+            name: 'distinctMessage',
+            description: 'distinct mqtt message',
+            providerUrl: 'http://192.168.1.2:5000/distinct/'
+        }
+    ]
+};
+
+config.http = {
+    port: 7896
+};
+
+config.amqp = {
+    port: 5672,
+    exchange: 'amq.topic',
+    queue: 'iota_queue',
+    options: {durable: true}
+};
+
+config.iota = {
+    logLevel: 'FATAL',
+    autocast: true,
+    contextBroker: {
+        host: '192.168.1.1',
+        port: '1026',
+        ngsiVersion: 'v2'
+    },
+    server: {
+        port: 4041
+    },
+    deviceRegistry: {
+        type: 'memory'
+    },
+
+    types: {},
+    service: 'howtoService',
+    subservice: '/howto',
+    providerUrl: 'http://localhost:4041',
+    deviceRegistrationDuration: 'P1M',
+    defaultType: 'Thing',
+    defaultResource: '/iot/d'
+};
+
+config.defaultKey = '1234';
+config.defaultTransport = 'HTTP';
+
+module.exports = config;

--- a/test/unit/ngsiv2/mqttBinding-dupcheck-test.js
+++ b/test/unit/ngsiv2/mqttBinding-dupcheck-test.js
@@ -1,0 +1,663 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ * Modified by: Fernando Mendez Requena  - ATOS Research & Innovation
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ *
+ * Modified by: Fernando Méndez, Daniel Calvo - ATOS Research & Innovation
+ *
+ * copy "mqttBinding-test" and edit to test duplication message checker by Nobuyuki Matsui<nobuyuki.matsui@gmail.com>
+ */
+
+'use strict';
+
+var iotagentUL = require('../../../'),
+    mqtt = require('mqtt'),
+    config = require('./config-dupcheck-test.js'),
+    nock = require('nock'),
+    iotAgentLib = require('iotagent-node-lib'),
+    async = require('async'),
+    request = require('request'),
+    utils = require('../../utils'),
+    contextBrokerMock,
+    dupCheckerMock,
+    mqttClient;
+
+
+describe('MQTT Transport binding with duplication checker: measures', function() {
+
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/deviceProvisioning/provisionDeviceMQTT.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        nock.cleanAll();
+
+        mqttClient = mqtt.connect('mqtt://' + config.mqtt.host, {
+            keepalive: 0,
+            connectTimeout: 60 * 60 * 1000
+        });
+
+        // This mock does not check the payload since the aim of the test is not to verify
+        // device provisioning functionality. Appropriate verification is done in tests under
+        // provisioning folder of iotagent-node-lib
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        dupCheckerMock = nock('http://192.168.1.2:5000')
+            .post('/distinct/')
+            .reply(200, {result: 'success'});
+
+        iotagentUL.start(config, function() {
+            request(provisionOptions, function(error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+        mqttClient.end();
+
+        async.series([
+            iotAgentLib.clearAll,
+            iotagentUL.stop
+        ], done);
+    });
+
+    describe('When a new non-duplicateed single measure arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a new update context request to the Context Broker with just that attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs/temperature', '23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicateed single measure arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a new update context request to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs/temperature', '23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When new non-duplicated multiple different format types measures arrives for a Device', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasuresTypeJson.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a new update context request to the Context Broker with just this attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs',
+                'luminosity|10|humidity|32|pollution|43.4|' +
+                'temperature|10|enabled|true|alive|null|tags' +
+                '|["iot","device"]|configuration|{"firmware":' +
+                '{"version":"1.1.0","hash":"cf23df2207d99a74fbe169e3eba035e633b65d94" } }',
+                 null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When new duplicated multiple different format types measures arrives for a Device', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasuresTypeJson.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a new update context request to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs',
+                'luminosity|10|humidity|32|pollution|43.4|' +
+                'temperature|10|enabled|true|alive|null|tags' +
+                '|["iot","device"]|configuration|{"firmware":' +
+                '{"version":"1.1.0","hash":"cf23df2207d99a74fbe169e3eba035e633b65d94" } }',
+                 null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated measure arrives for an unprovisioned Device', function() {
+        var groupCreation = {
+                url: 'http://localhost:4041/iot/services',
+                method: 'POST',
+                json: utils.readExampleFile('./test/unit/ngsiv2/groupProvisioning/provisionFullGroup.json'),
+                headers: {
+                    'fiware-service': 'TestService',
+                    'fiware-servicepath': '/testingPath'
+                }
+            };
+
+        beforeEach(function(done) {
+            // This mock does not check the payload since the aim of the test is not to verify
+            // device provisioning functionality. Appropriate verification is done in tests under
+            // provisioning folder of iotagent-node-lib
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v2/entities?options=upsert')
+                .reply(204);
+
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v2/entities/SensorMachine:UL_UNPROVISIONED/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+
+            request(groupCreation, function(error, response, body) {
+                done();
+            });
+        });
+
+        it('should send a new update context request to the Context Broker with just that attribute', function(done) {
+            mqttClient.publish('/80K09H324HV8732/UL_UNPROVISIONED/attrs/temperature', '23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated measure arrives for an unprovisioned Device', function() {
+        var groupCreation = {
+                url: 'http://localhost:4041/iot/services',
+                method: 'POST',
+                json: utils.readExampleFile('./test/unit/ngsiv2/groupProvisioning/provisionFullGroup.json'),
+                headers: {
+                    'fiware-service': 'TestService',
+                    'fiware-servicepath': '/testingPath'
+                }
+            };
+
+        beforeEach(function(done) {
+            // This mock does not check the payload since the aim of the test is not to verify
+            // device provisioning functionality. Appropriate verification is done in tests under
+            // provisioning folder of iotagent-node-lib
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v2/entities?options=upsert')
+                .reply(204);
+
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'TestService')
+                .matchHeader('fiware-servicepath', '/testingPath')
+                .post('/v2/entities/SensorMachine:UL_UNPROVISIONED/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+
+            request(groupCreation, function(error, response, body) {
+                done();
+            });
+        });
+
+        it('should not send a new update context request to the Context Broker', function(done) {
+            mqttClient.publish('/80K09H324HV8732/UL_UNPROVISIONED/attrs/temperature', '23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated multiple measure arrives to a Device topic with one measure', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a single update context request with all the attributes', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated multiple measure arrives to a Device topic with one measure', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a single update context request with all the attributes', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new non-duplicated multiple measure arrives to a Device topic with a faulty payload', function() {
+        beforeEach(function() {
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should silently ignore the error (without crashing)', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'notAULPayload ', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a new duplicated multiple measure arrives to a Device topic with a faulty payload', function() {
+        beforeEach(function() {
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should silently ignore the error (without crashing)', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'notAULPayload ', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When non-duplicated single message with multiple measures arrive to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send one update context per measure group to the Contet Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23|humidity|98', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When duplicated single message with multiple measures arrive to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send one update context per measure group to the Contet Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23|humidity|98', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a non-duplicated message with multiple measure groups arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                     utils.readExampleFile('./test/unit/ngsiv2/contextRequests/secondSingleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a two update context requests to the Context Broker one with each attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23#humidity|98', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a duplicated message with multiple measure groups arrives to a Device topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleMeasure.json'))
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                     utils.readExampleFile('./test/unit/ngsiv2/contextRequests/secondSingleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a two update context requests to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23#humidity|98', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When non-duplicated multiple groups of measures arrive, with multiple attributes, to a Device topic',
+        function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasure.json'))
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/secondMultipleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+        });
+
+        it('should send a two update context requests to the Context Broker one with each attribute', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23|humidity|' +
+                '98#temperature|16|' +
+                'humidity|34', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When duplicated multiple groups of measures arrive, with multiple attributes, to a Device topic',
+        function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/multipleMeasure.json'))
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities/Second%20UL%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/secondMultipleMeasure.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+        });
+
+        it('should not send a two update context requests to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/attrs', 'temperature|23|humidity|' +
+                '98#temperature|16|' +
+                'humidity|34', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a non-duplicated measure with a timestamp arrives with an alias to TimeInstant', function() {
+        var provisionProduction = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'POST',
+                 json: utils.readExampleFile('./test/unit/ngsiv2/deviceProvisioning/provisionTimeInstant.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+        beforeEach(function(done) {
+            // This mock does not check the payload since the aim of the test is not to verify
+            // device provisioning functionality. Appropriate verification is done in tests under
+            // provisioning folder of iotagent-node-lib
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities?options=upsert')
+                .reply(204)
+                .post('/v2/entities/TimeInstant%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/timeInstantDuplicated.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(200, {result: 'success'});
+
+            config.iota.timestamp = true;
+
+            nock('http://localhost:8082')
+                .post('/protocols')
+                .reply(200, {});
+
+            iotagentUL.stop(function() {
+                iotagentUL.start(config, function(error) {
+                    request(provisionProduction, function(error, response, body) {
+                        done();
+                    });
+                });
+            });
+        });
+
+        afterEach(function() {
+            config.iota.timestamp = false;
+        });
+
+        it('should use the provided TimeInstant as the general timestamp for the measures', function(done) {
+            mqttClient.publish(
+                '/1234/timestampedDevice/attrs',
+                'tmp|24.4|tt|2016-09-26T12:19:26.476659Z', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a duplicated measure with a timestamp arrives with an alias to TimeInstant', function() {
+        var provisionProduction = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'POST',
+                 json: utils.readExampleFile('./test/unit/ngsiv2/deviceProvisioning/provisionTimeInstant.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+        beforeEach(function(done) {
+            // This mock does not check the payload since the aim of the test is not to verify
+            // device provisioning functionality. Appropriate verification is done in tests under
+            // provisioning folder of iotagent-node-lib
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities?options=upsert')
+                .reply(204)
+                .post('/v2/entities/TimeInstant%20Device/attrs',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/timeInstantDuplicated.json'))
+                .reply(204);
+
+            dupCheckerMock
+                .post('/distinct/')
+                .reply(409, {result: 'duplicate'});
+
+            config.iota.timestamp = true;
+
+            nock('http://localhost:8082')
+                .post('/protocols')
+                .reply(200, {});
+
+            iotagentUL.stop(function() {
+                iotagentUL.start(config, function(error) {
+                    request(provisionProduction, function(error, response, body) {
+                        done();
+                    });
+                });
+            });
+        });
+
+        afterEach(function() {
+            config.iota.timestamp = false;
+        });
+
+        it('should not send a update context request to the Context Broker', function(done) {
+            mqttClient.publish(
+                '/1234/timestampedDevice/attrs',
+                'tmp|24.4|tt|2016-09-26T12:19:26.476659Z', null, function(error) {
+                setTimeout(function() {
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
this pull request fixes issue #151 

When `iotagent-ul` in a High Availability architecture (active - active), a MQTT message is processed as many times as the number of `iotagent-ul` . Because the each `iotagent-ul` subscribes for the same topic of MQTT Broker, so a MQTT message published that topic is processed by each `iotagent-ul` individually.

This pull request fixes above problem.

1. When a MQTT message is received, each `iotagent-ul` calls a RESTAPI before processing the message.
    * The url of its RESTAPI is configured by `config.js`.
1. If its RESTAPI returns `200 OK`,  `iotagent-ul` continues processing the MQTT message as ordinary. But if its RESTAPI returns 409 Conflict, `iotagent-ul` stops processing.

This pull request assumes that the "RESTAPI" service to check message duplication is outside of `iotagent-ul`.

An example implementation is like below:  
https://github.com/tech-sketch/fiware-mqtt-msgfilter