### PR TITLE
Update to standard-readme format

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This project is part of [FIWARE](https://www.fiware.org/). For more information
 check the FIWARE Catalogue entry for the
 [IoT Agents](https://github.com/Fiware/catalogue/tree/master/iot-agents).
 
+| :books: [Documentation](https://fiware-iotagent-ul.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/iot-agents/idas) | :whale: [Docker Hub](https://hub.docker.com/r/fiware/iotagent-ul/) |
+|---|---|---|
+
+
 ## Contents
 
 -   [Background](#background)

--- a/README.md
+++ b/README.md
@@ -8,56 +8,123 @@
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-iotagent-ul.svg)](http://fiware-iotagent-ul.readthedocs.org/en/latest/?badge=latest)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/iot-ultralight.svg)
 
-## Index
+An Internet of Things Agent for the Ultralight 2.0 protocol (with
+[AMQP](https://www.amqp.org/), [HTTP](https://www.w3.org/Protocols/) and
+[MQTT](https://mqtt.org/) transports). This IoT Agent is designed to be a bridge
+between Ultralight and the
+[NGSI](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/ngsiv2/ngsiv2-openapi.json)
+interface of a context broker.
 
-* [Description](#description)
-* [Installation](#installation)
-* [API Overview](#api-overview)
-* [API Reference Documentation](#api-reference-documentation)
-* [Development documentation](#development-documentation)
-* [Testing](#testing)
+It is based on the
+[IoT Agent Node.js Library](https://github.com/telefonicaid/iotagent-node-lib).
+Further general information about the FIWARE IoT Agents framework, its
+architecture and the common interaction model can be found in the library's
+GitHub repository.
 
-## Description
-This *Internet of Things Agent* is a bridge that can be used to communicate devices using the Ultralight 2.0 protocol
-and NGSI Context Brokers (like [Orion](https://github.com/telefonicaid/fiware-orion)). Ultralight 2.0 is a lightweight
-text based protocol aimed to constrained devices and communications where the bandwidth and device memory may be limited
-resources. This IoT Agent will provide different transport protocol bindings for the same protocol: HTTP, MQTT...
+This project is part of [FIWARE](https://www.fiware.org/). For more information
+check the FIWARE Catalogue entry for the
+[IoT Agents](https://github.com/Fiware/catalogue/tree/master/iot-agents).
 
-As is the case in any IoT Agent, this one follows the interaction model defined in the [Node.js IoT Agent Library](https://github.com/telefonicaid/iotagent-node-lib),
-that is used for the implementation of the APIs found on the IoT Agent's North Port.
-Information about the architecture of the IoT Agent can be found on that global repository.
-This documentation will only address those features and characteristics
-that are particular to the Ultralight 2.0 IoT Agent.
+## Contents
 
-Additional information about operating the component can be found in the [Operations: logs and alarms](docs/operations.md) document.
+-   [Background](#background)
+-   [Install](#install)
+-   [Usage](#usage)
+-   [API](#api)
+-   [Testing](#testing)
+-   [Quality Assurance](#quality-assurance)
+-   [License](#license)
 
-This project is part of [FIWARE](https://www.fiware.org/). Check also the [FIWARE Catalogue entry for the IoTAgents](http://catalogue.fiware.org/enablers/backend-device-management-idas)
+## Background
 
-## Installation
-Information about how to install the UL IoTAgent can be found at the corresponding section of the [Installation & Administration Guide](docs/installationguide.md).
+This _Internet of Things Agent_ is a bridge that can be used to communicate
+devices using the Ultralight 2.0 protocol and NGSI Context Brokers (like
+[Orion](https://github.com/telefonicaid/fiware-orion)). Ultralight 2.0 is a
+lightweight text based protocol aimed to constrained devices and communications
+where the bandwidth and device memory may be limited resources. This IoT Agent
+will provide different transport protocol bindings for the same protocol: HTTP,
+MQTT...
 
-## API Overview
+As is the case in any IoT Agent, this one follows the interaction model defined
+in the
+[Node.js IoT Agent Library](https://github.com/telefonicaid/iotagent-node-lib),
+that is used for the implementation of the APIs found on the IoT Agent's North
+Port. Information about the architecture of the IoT Agent can be found on that
+global repository. This documentation will only address those features and
+characteristics that are particular to the Ultralight 2.0 IoT Agent.
 
-An Overview of the API can be found in the [User & Programmers Manual](docs/usermanual.md).
+Additional information about operating the component can be found in the
+[Operations: logs and alarms](docs/operations.md) document.
 
-## API Reference Documentation
+## Install
 
-Apiary reference for the Configuration API can be found [here](http://docs.telefonicaiotiotagents.apiary.io/#reference/configuration-api).
-More information about IoTAgents and their APIs can be found in the IoTAgent Library [here](https://github.com/telefonicaid/iotagent-node-lib).
+Information about how to install the IoT Agent for Ultralight can be found at
+the corresponding section of the
+[Installation & Administration Guide](https://fiware-iotagent-ul.readthedocs.io/en/latest/installationguide).
 
-## Development documentation
+## Usage
 
-Information about developing for the UL IoTAgent can be found at the corresponding section of the [User & Programmers Manual](docs/usermanual.md).
+Information about how to use the IoT Agent can be found in the
+[User & Programmers Manual](https://fiware-iotagent-ul.readthedocs.io/en/latest/usermanual).
+
+## API
+
+Apiary reference for the Configuration API can be found
+[here](http://docs.telefonicaiotiotagents.apiary.io/#reference/configuration-api).
+More information about IoT Agents and their APIs can be found in the IoT Agent
+Library [documentation](https://iotagent-node-lib.rtfd.io/).
 
 ## Testing
-[Mocha](http://visionmedia.github.io/mocha/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.
 
-The test environment is preconfigured to run BDD testing style.
+[Mocha](https://mochajs.org/) Test Runner + [Chai](http://chaijs.com/) Assertion
+Library + [Sinon](http://sinonjs.org/) Spies, stubs.
 
-Module mocking during testing can be done with [proxyquire](https://github.com/thlorenz/proxyquire)
+The test environment is preconfigured to run [BDD](http://chaijs.com/api/bdd/)
+testing style with `chai.expect` and `chai.should()` available globally while
+executing tests, as well as the
+[Sinon-Chai](http://chaijs.com/plugins/sinon-chai) plugin.
+
+Module mocking during testing can be done with
+[proxyquire](https://github.com/thlorenz/proxyquire)
 
 To run tests, type
 
-```bash
-npm test
+```console
+grunt test
 ```
+
+Tests reports can be used together with Jenkins to monitor project quality
+metrics by means of TAP or XUnit plugins. To generate TAP report in
+`report/test/unit_tests.tap`, type
+
+```console
+grunt test-report
+```
+
+## Quality Assurance
+
+This project is part of [FIWARE](https://fiware.org/) and has been rated as
+follows:
+
+-   **Version Tested:**
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Version&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.version&colorB=blue)
+-   **Documentation:**
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Completeness&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.docCompleteness&colorB=blue)
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Usability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.docSoundness&colorB=blue)
+-   **Responsiveness:**
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Time%20to%20Respond&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.timeToCharge&colorB=blue)
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Time%20to%20Fix&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.timeToFix&colorB=blue)
+-   **FIWARE Testing:**
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Tests%20Passed&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.failureRate&colorB=blue)
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Scalability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.scalability&colorB=blue)
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Performance&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.performance&colorB=blue)
+    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Stability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.stability&colorB=blue)
+
+---
+
+## Licence
+
+The IoT Agent for Ultralight is licensed under Affero General Public License
+(GPL) version 3.
+
+© 2018 Telefonica Investigación y Desarrollo, S.A.U

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ Additional information about operating the component can be found in the
 
 Information about how to install the IoT Agent for Ultralight can be found at
 the corresponding section of the
-[Installation & Administration Guide](https://fiware-iotagent-ul.readthedocs.io/en/latest/installationguide).
+[Installation & Administration Guide](docs/installationguide.md).
+
+A `Dockerfile` is also available for your use - further information can be found [here](docker/README.md)
 
 ## Usage
 
 Information about how to use the IoT Agent can be found in the
-[User & Programmers Manual](https://fiware-iotagent-ul.readthedocs.io/en/latest/usermanual).
+[User & Programmers Manual](docs/usermanual.md).
 
 ## API
 
@@ -73,6 +75,8 @@ Apiary reference for the Configuration API can be found
 [here](http://docs.telefonicaiotiotagents.apiary.io/#reference/configuration-api).
 More information about IoT Agents and their APIs can be found in the IoT Agent
 Library [documentation](https://iotagent-node-lib.rtfd.io/).
+
+The latest IoT Agent for Ultralight documentation is also available on [ReadtheDocs](https://fiware-iotagent-ul.readthedocs.io/en/latest/)
 
 ## Testing
 
@@ -110,7 +114,7 @@ follows:
 
 ---
 
-## Licence
+## License
 
 The IoT Agent for Ultralight is licensed under Affero General Public License
 (GPL) version 3.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ check the FIWARE Catalogue entry for the
 -   [Usage](#usage)
 -   [API](#api)
 -   [Testing](#testing)
--   [Quality Assurance](#quality-assurance)
 -   [License](#license)
 
 ## Background
@@ -95,26 +94,6 @@ To run tests, type
 ```console
 npm test
 ```
-
-
-## Quality Assurance
-
-This project is part of [FIWARE](https://fiware.org/) and has been rated as
-follows:
-
--   **Version Tested:**
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Version&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.version&colorB=blue)
--   **Documentation:**
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Completeness&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.docCompleteness&colorB=blue)
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Usability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.docSoundness&colorB=blue)
--   **Responsiveness:**
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Time%20to%20Respond&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.timeToCharge&colorB=blue)
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Time%20to%20Fix&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.timeToFix&colorB=blue)
--   **FIWARE Testing:**
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Tests%20Passed&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.failureRate&colorB=blue)
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Scalability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.scalability&colorB=blue)
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Performance&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.performance&colorB=blue)
-    ![ ](https://img.shields.io/badge/dynamic/json.svg?label=Stability&url=https://fiware.github.io/catalogue/json/iotagent_ul.json&query=$.stability&colorB=blue)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,30 +76,18 @@ Library [documentation](https://iotagent-node-lib.rtfd.io/).
 
 ## Testing
 
-[Mocha](https://mochajs.org/) Test Runner + [Chai](http://chaijs.com/) Assertion
-Library + [Sinon](http://sinonjs.org/) Spies, stubs.
+[Mocha](http://visionmedia.github.io/mocha/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.
 
-The test environment is preconfigured to run [BDD](http://chaijs.com/api/bdd/)
-testing style with `chai.expect` and `chai.should()` available globally while
-executing tests, as well as the
-[Sinon-Chai](http://chaijs.com/plugins/sinon-chai) plugin.
+The test environment is preconfigured to run BDD testing style.
 
-Module mocking during testing can be done with
-[proxyquire](https://github.com/thlorenz/proxyquire)
+Module mocking during testing can be done with [proxyquire](https://github.com/thlorenz/proxyquire)
 
 To run tests, type
 
 ```console
-grunt test
+npm test
 ```
 
-Tests reports can be used together with Jenkins to monitor project quality
-metrics by means of TAP or XUnit plugins. To generate TAP report in
-`report/test/unit_tests.tap`, type
-
-```console
-grunt test-report
-```
 
 ## Quality Assurance
 


### PR DESCRIPTION
* Formatted Markdown file
* Added lede at the top of file so a description paragraph will display on mobile
* Standardized Section names (e.g. Introduction => Install)
* ~Added standard QA section - TSC **must** requirement~
* Expanded License to include copyrights
* Updated catalogue links to GitHub location
* Minor grammar corrections and text updates to improve the flow

[standard-readme](https://github.com/RichardLitt/standard-readme) is a simple standard naming convention for README files which makes reading and navigation of the documentation easier - this is a TSC **should** requirement