### PR TITLE
Feature/add coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ before_install:
 
 before_script:
   - npm run lint
+
+after_script: 
+  - npm run test:coveralls

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <br/>
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-iotagent-ul.svg)](http://fiware-iotagent-ul.readthedocs.org/en/latest/?badge=latest)
 [![Build badge](https://img.shields.io/travis/telefonicaid/iotagent-ul.svg)](https://travis-ci.org/telefonicaid/iotagent-ul/)
+[![Coverage Status](https://coveralls.io/repos/github/telefonicaid/iotagent-ul/badge.svg?branch=master)](https://coveralls.io/github/telefonicaid/iotagent-ul?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/iot-ultralight.svg)
 
 An Internet of Things Agent for the Ultralight 2.0 protocol (with

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
-    "test:coveralls": "npm run test:coverage && && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
@@ -40,6 +40,7 @@
     "underscore": "1.9.1"
   },
   "devDependencies": {
+    "coveralls": "^3.0.2",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
     "mocha": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coveralls": "npm run test:coverage && && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {


### PR DESCRIPTION
Expose Code Coverage results to Coveralls. Runs `npm test:coverage` after the unit tests and then sends the results to [coveralls](https://coveralls.io)

the repo needs to be exposed on coveralls as well (obviously) - see https://coveralls.io/repos/new

- SHOULD requirement from TSC