### PR TITLE
Fix #320 - Reverting to previous MQTT functionality from 1.7.0

### DIFF
--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -184,9 +184,10 @@ function retrieveDevice(deviceId, apiKey, transport, callback) {
             }
         });
     } else {
+        var defaultResource = transport === 'HTTP' ? config.getConfig().iota.defaultResource : '';
         async.waterfall(
             [
-                apply(iotAgentLib.getConfiguration, config.getConfig().iota.defaultResource, apiKey),
+                apply(iotAgentLib.getConfiguration, defaultResource, apiKey),
                 apply(findOrCreate, deviceId, transport),
                 mergeDeviceWithConfiguration
             ],


### PR DESCRIPTION
Only set default resource if using the HTTP Transport. Use blank otherwise.