### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,10 @@
 site_name: Fiware-iotagent-ul
 site_url: https://fiware-iotagent-ul.readthedocs.org
-repo_url: https://github.com/telefonicaid/iotagent-ul.git
+repo_url: https://github.com/telefonicaid/iotagent-ul
 site_description: IoT Agent Ultralight2.0 (HTTP or MQTT) Documentation
 docs_dir: docs
 site_dir: html
+edit_uri: edit/master/docs/
 markdown_extensions: [toc,fenced_code]
 use_directory_urls: false
 theme: readthedocs


### PR DESCRIPTION
Adding the right config parameter, according to mkdocs instructions will fix documentation broken links:
https://www.mkdocs.org/user-guide/configuration/#edit_uri
The same fix has been applied successfully in other similar repositories:
telefonicaid/fiware-orion#3491
Also this must be changed:
Repo URL must be:
repo_url: https://github.com/telefonicaid/iotagent-ul
Instead of
repo_url: https://github.com/telefonicaid/iotagent-ul.git