### PR TITLE
Add PM2_ENABLED flag to Docker

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- ADD PM2_ENABLED flag to Docker

--- a/docker/README.md
+++ b/docker/README.md
@@ -164,7 +164,7 @@ docker run --name iotagent -e PM2_ENABLED=true -d fiware/iotagent-ul
 
 Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
 your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
-Kubenetes)
+[Kubernetes](https://kubernetes.io/))
 
 ### Docker Secrets
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,8 +132,8 @@ docker build -t iot-agent . --build-arg DOWNLOAD=1.7.0
 
 ## Building from your own fork
 
-To download code from your own fork of the GitHub repository add the `GITHUB_ACCOUNT`, `GITHUB_REPOSITORY`
-and `SOURCE_BRANCH` arguments (default `master`) to the `docker build` command.
+To download code from your own fork of the GitHub repository add the `GITHUB_ACCOUNT`, `GITHUB_REPOSITORY` and
+`SOURCE_BRANCH` arguments (default `master`) to the `docker build` command.
 
 ```console
 docker build -t iot-agent . \
@@ -152,6 +152,19 @@ COPY . /opt/iotaul/
 ```
 
 Full instructions can be found within the `Dockerfile` itself.
+
+### Using PM2
+
+The IoT Agent within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/) Process
+Manager by adding the `PM2_ENABLED` environment variable.
+
+```console
+docker run --name iotagent -e PM2_ENABLED=true -d fiware/iotagent-ul
+```
+
+Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
+your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
+Kubenetes)
 
 ### Docker Secrets
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,4 +65,12 @@ else
     fi
 fi
 
-pm2-runtime /opt/iotaul/bin/iotagent-ul
+if [[  -z "$PM2_ENABLED" ]]; then
+    echo "INFO: IoT Agent running standalone"
+    node /opt/iotaul/bin/iotagent-ul
+else
+    echo "***********************************************"
+    echo "INFO: IoT Agent encapsulated by pm2-runtime see https://pm2.io/doc/en/runtime/integration/docker/"
+    echo "***********************************************"
+    pm2-runtime /opt/iotaul/bin/iotagent-ul
+fi


### PR DESCRIPTION
This PR is a potential fix for https://github.com/telefonicaid/iotagent-node-lib/issues/790

* Update entrypoint to use/not use pm2
* Add `PM2_ENABLED` to Docker README
* Update CNR.