### PR TITLE
HTTP Swagger

### DIFF
--- a/lib/bindings/HTTPBindings.js
+++ b/lib/bindings/HTTPBindings.js
@@ -42,6 +42,8 @@ var http = require('http'),
     context = {
         op: 'IOTAUL.HTTP.Binding'
     },
+    swaggerUi = require('swagger-ui-express'),
+    swaggerJSDoc = require('swagger-jsdoc'),
     transport = 'HTTP';
 
 function handleError(error, req, res, next) {
@@ -406,10 +408,69 @@ function start(callback) {
         router: express.Router()
     };
 
+    var options = {
+        swaggerDefinition: {
+            info: {
+                title: 'IoT Agent UL2 - HTTP', // Title (required)
+                version: '1.0.0', // Version (required)
+                description: 'This documentation explains the POST and GET requests to the route /iot/d' // Description (not required)
+            }
+        },
+        apis: ['./lib/bindings/*'] // Path to the API docs
+    };
+    var swaggerSpec = swaggerJSDoc(options);
+
+    httpBindingServer.app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
     config.getLogger().info(context, 'HTTP Binding listening on port [%s]', config.getConfig().http.port);
 
     httpBindingServer.app.set('port', config.getConfig().http.port);
     httpBindingServer.app.set('host', config.getConfig().http.host || '0.0.0.0');
+
+    /**
+     * @swagger
+     *
+     * /iot/d:
+     *    get:
+     *      tags:
+     *      - "iot/d"
+     *      summary: "Report new measures"
+     *      description: "A device can report new measures to the IoT Platform using an HTTP GET request to the /iot/d path"
+     *      consumes:
+     *      - "application/json"
+     *      produces:
+     *      - "application/json"
+     *      parameters:
+     *       - in: "query"
+     *         name: "i"
+     *         description: "Device ID"
+     *         type: string
+     *         required: true
+     *       - in: "query"
+     *         name: "k"
+     *         description: "API Key for the service the device is registered on"
+     *         type: string
+     *         required: true
+     *       - in: "query"
+     *         name: "d"
+     *         description: "Ultralight 2.0 payload. Payloads for GET requests should not contain multiple measure groups"
+     *         type: string
+     *         required: true
+     *       - in: "query"
+     *         name: "t"
+     *         description: "Timestamp of the measure"
+     *         type: timestamp
+     *         required: false
+     *      responses:
+     *        200:
+     *          description: "The new measure has been registered "
+     *        404:
+     *          description: 'No device was found with "device_name"'
+     *        DEVICE_GROUP_NOT_FOUND:
+     *          description: "Could not find device group"
+     *        PARSE_ERROR:
+     *          description: 'There was a syntax error in the Ultralight request: Unknown error parsing Ultralight 2.0: "syntax_error"'
+     */
 
     httpBindingServer.router.get(
         config.getConfig().iota.defaultResource || constants.HTTP_MEASURE_PATH,
@@ -419,6 +480,50 @@ function start(callback) {
         handleIncomingMeasure,
         returnCommands
     );
+
+    /**
+     * @swagger
+     *
+     * /iot/d:
+     *    post:
+     *      tags:
+     *      - "iot/d"
+     *      summary: "Registrer a new measure"
+     *      description: "This request add a new measure to the datebase."
+     *      operationId: "addDevices"
+     *      consumes:
+     *        - text/plain
+     *      parameters:
+     *      - in: query
+     *        name: "i"
+     *        description: "Device ID"
+     *        type: string
+     *        required: true
+     *      - in: query
+     *        name: "k"
+     *        description: "API key. Service identification."
+     *        type: string
+     *        required: true
+     *      - in: query
+     *        name: "t"
+     *        description: "Date and time of register"
+     *        type: timestamp
+     *        required: false
+     *      - in: body
+     *        name: "Sensors"
+     *        description: 'Sensors Measurements. The different sensor values ​​are sent in IoT Agent format. For example: "c|1"'
+     *        type: string
+     *        required: true
+     *      responses:
+     *        200:
+     *          description: "Report new measures to the IoT Platform"
+     *        404:
+     *          description: 'DEVICE_NOT_FOUND - No device was found with "device_name"'
+     *        DEVICE_GROUP_NOT_FOUND:
+     *          description: "Could not find device group"
+     *        PARSE_ERROR:
+     *          description: 'There was a syntax error in the Ultralight request: Unknown error parsing Ultralight 2.0: "syntax_error"'
+     */
 
     httpBindingServer.router.post(
         config.getConfig().iota.defaultResource || constants.HTTP_MEASURE_PATH,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",
+    "swagger-jsdoc": "^3.4.0",
+    "swagger-ui-express": "^4.1.2",
     "underscore": "1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request contains improvements made by the Secmotic team for iotagent-ul. These improvements are part of the fiQare project, which is based on ISO 25010 to improve software quality. More info: https://fiqare.eu/

Swagger is provided for HTTP protocol in:
`<server_host>:7896/api-docs`

**Note: npm install is needed**

All test in Travis has been passed successfully and the coverage in Coveralls remains the same.