### PR TITLE
Add AMPQ, MQTT and Mongo-DB User and Password as Docker Secrets

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -183,6 +183,8 @@ Currently, this `_FILE` suffix is supported for:
 -   `IOTA_AUTH_PASSWORD`
 -   `IOTA_AUTH_CLIENT_ID`
 -   `IOTA_AUTH_CLIENT_SECRET`
+-   `IOTA_MONGO_USER`
+-   `IOTA_MONGO_PASSWORD`
 
 ## Best Practices
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -185,6 +185,11 @@ Currently, this `_FILE` suffix is supported for:
 -   `IOTA_AUTH_CLIENT_SECRET`
 -   `IOTA_MONGO_USER`
 -   `IOTA_MONGO_PASSWORD`
+-   `IOTA_MQTT_KEY`
+-   `IOTA_MQTT_USERNAME`
+-   `IOTA_MQTT_PASSWORD`
+-   `IOTA_AMQP_USERNAME`
+-   `IOTA_AMQP_PASSWORD`
 
 ## Best Practices
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,7 +48,12 @@ file_env 'IOTA_AUTH_PASSWORD'
 file_env 'IOTA_AUTH_CLIENT_ID'
 file_env 'IOTA_AUTH_CLIENT_SECRET'
 file_env 'IOTA_MONGO_USER'
-file_env 'IOTA_MONGO_PASSWORD
+file_env 'IOTA_MONGO_PASSWORD'
+file_env 'IOTA_MQTT_KEY'
+file_env 'IOTA_MQTT_USERNAME'
+file_env 'IOTA_MQTT_PASSWORD'
+file_env 'IOTA_AMQP_USERNAME'
+file_env 'IOTA_AMQP_PASSWORD'
 
 
 if [[  -z "$IOTA_AUTH_ENABLED" ]]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -47,6 +47,8 @@ file_env 'IOTA_AUTH_USER'
 file_env 'IOTA_AUTH_PASSWORD'
 file_env 'IOTA_AUTH_CLIENT_ID'
 file_env 'IOTA_AUTH_CLIENT_SECRET'
+file_env 'IOTA_MONGO_USER'
+file_env 'IOTA_MONGO_PASSWORD
 
 
 if [[  -z "$IOTA_AUTH_ENABLED" ]]; then


### PR DESCRIPTION
Once Mongo-DB  User and Password are fully supported within the iot-node-lib, they should be made available obfuscated within Docker 

Related: https://github.com/telefonicaid/iotagent-node-lib/pull/852