### PR TITLE
Add Southbound HTTPS support + Standardize MQTT

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Fix: move to warn error log about device not found
 - Add: check response obj before use it handling http commands
-- Add Southbound HTTPS support + Standardize MQTT-SSL support (#422)
+- Add Southbound HTTPS support (#422)
+- Add Standardized MQTT-SSL support (#354)
 - Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Fix: move to warn error log about device not found
 - Add: check response obj before use it handling http commands
+- Add Southbound HTTPS support + Standardize MQTT-SSL support (#422)
 - Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/config.js
+++ b/config.js
@@ -47,6 +47,12 @@ config.mqtt = {
     //password: ''
 
     /**
+     * Set to `false` if using a self-signed certificate.
+     * Beware that you are exposing yourself to man in the middle attacks
+     */
+    //rejectUnauthorized: true
+
+    /**
      * QoS Level: at most once (0), at least once (1), exactly once (2). (default is 2).
      */
     qos: 0,
@@ -94,6 +100,14 @@ config.http = {
      * HTTP Timeout for the http command endpoint (in milliseconds).
      */
     //timeout: 1000
+    /**
+     * Path to your private key for HTTPS binding
+     */
+    // privateKey: <path_to_private_key>
+    /**
+     * Path to your certificate for HTTPS binding
+     */
+    // certificate: <path_to_cert>
 };
 
 config.iota = {

--- a/config.js
+++ b/config.js
@@ -37,6 +37,12 @@ config.mqtt = {
     port: 1883,
 
     /**
+     * protocol to use for connecting with the MQTT broker
+     * (`mqtt`, `mqtts`, `tcp`, `tls`, `ws`, `wss`)
+     */
+    //protocol = 'mqtt'
+
+    /**
      * User name for the IoTAgent in the MQTT broker, if authentication is activated.
      */
     //username: ''
@@ -51,6 +57,19 @@ config.mqtt = {
      * Beware that you are exposing yourself to man in the middle attacks
      */
     //rejectUnauthorized: true
+
+    /**
+     * Path to your certification authority for MQTT binding over SSL
+     */
+    //ca = <path_to_ca>
+    /**
+     * Path to your private key for MQTT binding over SSL
+     */
+    // key: <path_to_private_key>
+    /**
+     * Path to your certificate for MQTT binding over SSL
+     */
+    // cert: <path_to_cert>
 
     /**
      * QoS Level: at most once (0), at least once (1), exactly once (2). (default is 2).
@@ -103,11 +122,11 @@ config.http = {
     /**
      * Path to your private key for HTTPS binding
      */
-    // privateKey: <path_to_private_key>
+    // key: <path_to_private_key>
     /**
      * Path to your certificate for HTTPS binding
      */
-    // certificate: <path_to_cert>
+    // cert: <path_to_cert>
 };
 
 config.iota = {

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -177,7 +177,6 @@ IoT Agent. The following attributes are accepted:
 -   **key**: optional private keys in PEM format to use on the client-side for connecting with the MQTT broker
     (optional). Only used when using `mqtts`, `tls` or `wss` as connection protocol. The included CA list will be used
     to determine if server is authorized.
--   **protocol**: MQTT protocol to use (default `mqtt`)
 -   **qos**: QoS level: at most once (`0`), at least once (`1`), exactly once (`2`). (default is `0`).
 -   **retain**: retain flag (default is `false`).
 -   **retries**: Number of MQTT connection error retries (default is 5).

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -166,6 +166,7 @@ The `config.mqtt` section of the config file contains all the information needed
 IoT Agent. The following attributes are accepted:
 
 -   **protocol**: protocol to use for connecting with the MQTT broker (`mqtt`, `mqtts`, `tcp`, `tls`, `ws`, `wss`).
+    The default is `mqtt`
 -   **host**: Host where the MQTT Broker is located.
 -   **port**: Port where the MQTT Broker is listening
 -   **username**: Username for the IoT Agent in the MQTT broker, if authentication is activated.

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -165,10 +165,19 @@ JavaScript file, that contains the following sections:
 The `config.mqtt` section of the config file contains all the information needed to connect to the MQTT Broker from the
 IoT Agent. The following attributes are accepted:
 
+-   **protocol**: protocol to use for connecting with the MQTT broker (`mqtt`, `mqtts`, `tcp`, `tls`, `ws`, `wss`).
 -   **host**: Host where the MQTT Broker is located.
 -   **port**: Port where the MQTT Broker is listening
 -   **username**: Username for the IoT Agent in the MQTT broker, if authentication is activated.
 -   **password**: Password for the IoT Agent in the MQTT broker, if authentication is activated.
+-   **ca**: ca certificates to use for validating server certificates (optional). Default is to trust the well-known CAs
+    curated by Mozilla. Mozilla's CAs are completely replaced when CAs are explicitly specified using this option.
+-   **cert**: cert chains in PEM format to use for authenticating into the MQTT broker (optional). Only used when using
+    `mqtts`, `tls` or `wss` as connnection protocol.
+-   **key**: optional private keys in PEM format to use on the client-side for connecting with the MQTT broker
+    (optional). Only used when using `mqtts`, `tls` or `wss` as connection protocol. The included CA list will be used
+    to determine if server is authorized.
+-   **protocol**: MQTT protocol to use (default `mqtt`)
 -   **qos**: QoS level: at most once (`0`), at least once (`1`), exactly once (`2`). (default is `0`).
 -   **retain**: retain flag (default is `false`).
 -   **retries**: Number of MQTT connection error retries (default is 5).
@@ -176,6 +185,10 @@ IoT Agent. The following attributes are accepted:
 -   **keepalive**: Time to keep connection open between client and MQTT broker (default is 0 seconds). If you experience
     disconnnection problems using 0 (as the one described in
     [this case](https://github.com/telefonicaid/iotagent-json/issues/455)) a value greater than 0 is recommended.
+-   **rejectUnauthorized** whether to reject any connection which is not authorized with the list of supplied CAs. This
+    option only has an effect when using `mqtts`, `tls` or `wss` protocols (default is `true`). Set to `false` if using
+    a self-signed certificate but beware that you are exposing yourself to man in the middle attacks, so it is a
+    configuration that is not recommended for production environments.
 
 #### AMQP Binding configuration
 
@@ -191,9 +204,6 @@ IoT Agent. The following attributes are accepted:
 -   **durable**: durable queue flag (default is `false`).
 -   **retries**: Number of AMQP connection error retries (default is 5).
 -   **retryTime**: Time between AMQP connection retries (default is 5 seconds).
--   **rejectUnauthorized** set to `false` if using a self-signed certificate. (default is `true`). Beware that you are
-    exposing yourself to man in the middle attacks, so it is a configuration that is not recommended for production
-    environments.
 
 #### HTTP Binding configuration
 
@@ -202,8 +212,8 @@ transport protocol binding. The following options are accepted:
 
 -   **port**: South Port where the HTTP listener will be listening for information from the devices.
 -   **timeout**: HTTP Timeout for the HTTP endpoint (in milliseconds).
--   **privateKey**: Path to your private key for HTTPS binding
--   **certificate**: Path to your certificate for HTTPS binding
+-   **key**: Path to your private key for HTTPS binding
+-   **cert**: Path to your certificate for HTTPS binding
 
 #### Configuration with environment variables
 
@@ -215,8 +225,13 @@ The ones relating specific Ultralight 2.0 bindings are described in the followin
 
 | Environment variable          | Configuration attribute |
 | :---------------------------- | :---------------------- |
+| IOTA_MQTT_PROTOCOL            | mqtt.protocol           |
 | IOTA_MQTT_HOST                | mqtt.host               |
 | IOTA_MQTT_PORT                | mqtt.port               |
+| IOTA_MQTT_CA                  | mqtt.ca                 |
+| IOTA_MQTT_CERT                | mqtt.cert               |
+| IOTA_MQTT_KEY                 | mqtt.key                |
+| IOTA_MQTT_REJECT_UNAUTHORIZED | mqtt.rejectUnauthorized |
 | IOTA_MQTT_USERNAME            | mqtt.username           |
 | IOTA_MQTT_PASSWORD            | mqtt.password           |
 | IOTA_MQTT_QOS                 | mqtt.qos                |
@@ -224,7 +239,6 @@ The ones relating specific Ultralight 2.0 bindings are described in the followin
 | IOTA_MQTT_RETRIES             | mqtt.retries            |
 | IOTA_MQTT_RETRY_TIME          | mqtt.retryTime          |
 | IOTA_MQTT_KEEPALIVE           | mqtt.keepalive          |
-| IOTA_MQTT_REJECT_UNAUTHORIZED | mqtt.rejectUnauthorized |
 | IOTA_AMQP_HOST                | amqp.host               |
 | IOTA_AMQP_PORT                | amqp.port               |
 | IOTA_AMQP_USERNAME            | amqp.username           |
@@ -237,8 +251,8 @@ The ones relating specific Ultralight 2.0 bindings are described in the followin
 | IOTA_HTTP_HOST                | http.host               |
 | IOTA_HTTP_PORT                | http.port               |
 | IOTA_HTTP_TIMEOUT             | http.timeout            |
-| IOTA_HTTP_PRIVATE_KEY         | http.privateKey         |
-| IOTA_HTTP_CERTIFICATE         | http.certificate        |
+| IOTA_HTTP_KEY                 | http.key                |
+| IOTA_HTTP_CERT                | http.cert               |
 
 #### High performance configuration
 

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -174,7 +174,8 @@ IoT Agent. The following attributes are accepted:
 -   **retries**: Number of MQTT connection error retries (default is 5).
 -   **retryTime**: Time between MQTT connection retries (default is 5 seconds).
 -   **keepalive**: Time to keep connection open between client and MQTT broker (default is 0 seconds). If you experience
-    disconnnection problems using 0 (as the one described in [this case](https://github.com/telefonicaid/iotagent-json/issues/455)) a value greater than 0 is recommended. 
+    disconnnection problems using 0 (as the one described in
+    [this case](https://github.com/telefonicaid/iotagent-json/issues/455)) a value greater than 0 is recommended.
 
 #### AMQP Binding configuration
 
@@ -190,6 +191,9 @@ IoT Agent. The following attributes are accepted:
 -   **durable**: durable queue flag (default is `false`).
 -   **retries**: Number of AMQP connection error retries (default is 5).
 -   **retryTime**: Time between AMQP connection retries (default is 5 seconds).
+-   **rejectUnauthorized** set to `false` if using a self-signed certificate. (default is `true`). Beware that you are
+    exposing yourself to man in the middle attacks, so it is a configuration that is not recommended for production
+    environments.
 
 #### HTTP Binding configuration
 
@@ -197,7 +201,9 @@ The `config.http` section of the config file contains all the information needed
 transport protocol binding. The following options are accepted:
 
 -   **port**: South Port where the HTTP listener will be listening for information from the devices.
--   **timeout**: HTTP Timeout for the HTTP endpoint (in miliseconds).
+-   **timeout**: HTTP Timeout for the HTTP endpoint (in milliseconds).
+-   **privateKey**: Path to your private key for HTTPS binding
+-   **certificate**: Path to your certificate for HTTPS binding
 
 #### Configuration with environment variables
 
@@ -207,29 +213,32 @@ in the `config.iota` set are described in the
 
 The ones relating specific Ultralight 2.0 bindings are described in the following table.
 
-| Environment variable | Configuration attribute |
-| :------------------- | :---------------------- |
-| IOTA_MQTT_HOST       | mqtt.host               |
-| IOTA_MQTT_PORT       | mqtt.port               |
-| IOTA_MQTT_USERNAME   | mqtt.username           |
-| IOTA_MQTT_PASSWORD   | mqtt.password           |
-| IOTA_MQTT_QOS        | mqtt.qos                |
-| IOTA_MQTT_RETAIN     | mqtt.retain             |
-| IOTA_MQTT_RETRIES    | mqtt.retries            |
-| IOTA_MQTT_RETRY_TIME | mqtt.retryTime          |
-| IOTA_MQTT_KEEPALIVE  | mqtt.keepalive          |
-| IOTA_AMQP_HOST       | amqp.host               |
-| IOTA_AMQP_PORT       | amqp.port               |
-| IOTA_AMQP_USERNAME   | amqp.username           |
-| IOTA_AMQP_PASSWORD   | amqp.password           |
-| IOTA_AMQP_EXCHANGE   | amqp.exchange           |
-| IOTA_AMQP_QUEUE      | amqp.queue              |
-| IOTA_AMQP_DURABLE    | amqp.durable            |
-| IOTA_AMQP_RETRIES    | amqp.retries            |
-| IOTA_AMQP_RETRY_TIME | amqp.retryTime          |
-| IOTA_HTTP_HOST       | http.host               |
-| IOTA_HTTP_PORT       | http.port               |
-| IOTA_HTTP_TIMEOUT    | http.timeout            |
+| Environment variable          | Configuration attribute |
+| :---------------------------- | :---------------------- |
+| IOTA_MQTT_HOST                | mqtt.host               |
+| IOTA_MQTT_PORT                | mqtt.port               |
+| IOTA_MQTT_USERNAME            | mqtt.username           |
+| IOTA_MQTT_PASSWORD            | mqtt.password           |
+| IOTA_MQTT_QOS                 | mqtt.qos                |
+| IOTA_MQTT_RETAIN              | mqtt.retain             |
+| IOTA_MQTT_RETRIES             | mqtt.retries            |
+| IOTA_MQTT_RETRY_TIME          | mqtt.retryTime          |
+| IOTA_MQTT_KEEPALIVE           | mqtt.keepalive          |
+| IOTA_MQTT_REJECT_UNAUTHORIZED | mqtt.rejectUnauthorized |
+| IOTA_AMQP_HOST                | amqp.host               |
+| IOTA_AMQP_PORT                | amqp.port               |
+| IOTA_AMQP_USERNAME            | amqp.username           |
+| IOTA_AMQP_PASSWORD            | amqp.password           |
+| IOTA_AMQP_EXCHANGE            | amqp.exchange           |
+| IOTA_AMQP_QUEUE               | amqp.queue              |
+| IOTA_AMQP_DURABLE             | amqp.durable            |
+| IOTA_AMQP_RETRIES             | amqp.retries            |
+| IOTA_AMQP_RETRY_TIME          | amqp.retryTime          |
+| IOTA_HTTP_HOST                | http.host               |
+| IOTA_HTTP_PORT                | http.port               |
+| IOTA_HTTP_TIMEOUT             | http.timeout            |
+| IOTA_HTTP_PRIVATE_KEY         | http.privateKey         |
+| IOTA_HTTP_CERTIFICATE         | http.certificate        |
 
 #### High performance configuration
 

--- a/lib/bindings/HTTPBindings.js
+++ b/lib/bindings/HTTPBindings.js
@@ -23,7 +23,9 @@
 
 'use strict';
 
-var http = require('http'),
+var fs = require('fs'),
+    http = require('http'),
+    https = require('https'),
     async = require('async'),
     apply = async.apply,
     iotAgentLib = require('iotagent-node-lib'),
@@ -406,8 +408,6 @@ function start(callback) {
         router: express.Router()
     };
 
-    config.getLogger().info(context, 'HTTP Binding listening on port [%s]', config.getConfig().http.port);
-
     httpBindingServer.app.set('port', config.getConfig().http.port);
     httpBindingServer.app.set('host', config.getConfig().http.host || '0.0.0.0');
 
@@ -434,8 +434,17 @@ function start(callback) {
     httpBindingServer.app.use(baseRoot, httpBindingServer.router);
     httpBindingServer.app.use(handleError);
 
-    httpBindingServer.server = http.createServer(httpBindingServer.app);
+    if (config.getConfig().http && config.getConfig().http.privateKey && config.getConfig().http.certificate) {
+        var privateKey = fs.readFileSync(config.getConfig().http.privateKey, 'utf8');
+        var certificate = fs.readFileSync(config.getConfig().http.certificate, 'utf8');
+        var credentials = { key: privateKey, cert: certificate };
 
+        config.getLogger().info(context, 'HTTPS Binding listening on port [%s]', config.getConfig().http.port);
+        httpBindingServer.server = https.createServer(credentials, httpBindingServer.app);
+    } else {
+        config.getLogger().info(context, 'HTTP Binding listening on port [%s]', config.getConfig().http.port);
+        httpBindingServer.server = http.createServer(httpBindingServer.app);
+    }
     httpBindingServer.server.listen(httpBindingServer.app.get('port'), httpBindingServer.app.get('host'), callback);
 }
 

--- a/lib/bindings/HTTPBindings.js
+++ b/lib/bindings/HTTPBindings.js
@@ -435,8 +435,8 @@ function start(callback) {
     httpBindingServer.app.use(handleError);
 
     if (config.getConfig().http && config.getConfig().http.privateKey && config.getConfig().http.certificate) {
-        var privateKey = fs.readFileSync(config.getConfig().http.privateKey, 'utf8');
-        var certificate = fs.readFileSync(config.getConfig().http.certificate, 'utf8');
+        var privateKey = fs.readFileSync(config.getConfig().http.key, 'utf8');
+        var certificate = fs.readFileSync(config.getConfig().http.cert, 'utf8');
         var credentials = { key: privateKey, cert: certificate };
 
         config.getLogger().info(context, 'HTTPS Binding listening on port [%s]', config.getConfig().http.port);

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -236,23 +236,12 @@ function start(callback) {
         rejectUnauthorized: rejectUnauthorized,
         username: mqttConfig.username ? mqttConfig.username : null,
         password: mqttConfig.password ? mqttConfig.password : null,
-        keepalive: 0,
+        keepalive: mqttConfig.keepalive ? parseInt(mqttConfig.keepalive) : 0,
         connectTimeout: 60 * 60 * 1000
     };
-    if (config.getConfig().mqtt.keepalive) {
-        options.keepalive = parseInt(config.getConfig().mqtt.keepalive) || 0;
-    }
-    var retries, retryTime;
-    if (mqttConfig.retries) {
-        retries = mqttConfig.retries;
-    } else {
-        retries = constants.MQTT_DEFAULT_RETRIES;
-    }
-    if (mqttConfig.retryTime) {
-        retryTime = mqttConfig.retryTime;
-    } else {
-        retryTime = constants.MQTT_DEFAULT_RETRY_TIME;
-    }
+
+    var retries = mqttConfig.retries ? mqttConfig.retries : constants.MQTT_DEFAULT_RETRIES;
+    var retryTime = mqttConfig.retryTime ? mqttConfig.retryTime : constants.MQTT_DEFAULT_RETRY_TIME;
     var isConnecting = false;
     var numRetried = 0;
     config.getLogger().info(context, 'Starting MQTT binding');

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -253,7 +253,7 @@ function start(callback) {
         }
         isConnecting = true;
         mqttClient = mqtt.connect(
-            options.protocol + '://' + config.getConfig().mqtt.host + ':' + config.getConfig().mqtt.port,
+            options.protocol + '://' + mqttConfig.host + ':' + mqttConfig.port,
             options
         );
         isConnecting = false;

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -231,6 +231,9 @@ function start(callback) {
         options.username = config.getConfig().mqtt.username;
         options.password = config.getConfig().mqtt.password;
     }
+    if (config.getConfig().mqtt.rejectUnauthorized !== undefined) {
+        options.rejectUnauthorized = config.getConfig().mqtt.rejectUnauthorized;
+    }
     if (config.getConfig().mqtt.keepalive) {
         options.keepalive = parseInt(config.getConfig().mqtt.keepalive) || 0;
     }

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -23,7 +23,8 @@
 
 'use strict';
 
-var iotAgentLib = require('iotagent-node-lib'),
+var fs = require('fs'),
+    iotAgentLib = require('iotagent-node-lib'),
     commonBindings = require('./../commonBindings'),
     utils = require('../iotaUtils'),
     ulParser = require('../ulParser'),
@@ -219,33 +220,36 @@ function sendConfigurationToDevice(apiKey, deviceId, results, callback) {
  * binding plugins.
  */
 function start(callback) {
-    if (!config.getConfig().mqtt) {
+    var mqttConfig = config.getConfig().mqtt;
+    if (!mqttConfig) {
         return config.getLogger().error(context, 'Error MQTT is not configured');
     }
+
+    var rejectUnauthorized = typeof mqttConfig.rejectUnauthorized === 'boolean' ? mqttConfig.rejectUnauthorized : true;
     var options = {
+        protocol: mqttConfig.protocol ? mqttConfig.protocol : 'mqtt',
+        host: mqttConfig.host ? mqttConfig.host : 'localhost',
+        port: mqttConfig.port ? mqttConfig.port : 1883,
+        key: mqttConfig.key ? fs.readFileSync(mqttConfig.key, 'utf8') : null,
+        ca: mqttConfig.ca ? fs.readFileSync(mqttConfig.ca, 'utf8') : null,
+        cert: mqttConfig.cert ? fs.readFileSync(mqttConfig.cert, 'utf8') : null,
+        rejectUnauthorized: rejectUnauthorized,
+        username: mqttConfig.username ? mqttConfig.username : null,
+        password: mqttConfig.password ? mqttConfig.password : null,
         keepalive: 0,
         connectTimeout: 60 * 60 * 1000
     };
-
-    if (config.getConfig().mqtt && config.getConfig().mqtt.username && config.getConfig().mqtt.password) {
-        options.username = config.getConfig().mqtt.username;
-        options.password = config.getConfig().mqtt.password;
-    }
-    if (config.getConfig().mqtt.rejectUnauthorized !== undefined) {
-        options.rejectUnauthorized = config.getConfig().mqtt.rejectUnauthorized;
-    }
     if (config.getConfig().mqtt.keepalive) {
         options.keepalive = parseInt(config.getConfig().mqtt.keepalive) || 0;
     }
     var retries, retryTime;
-
-    if (config.getConfig() && config.getConfig().mqtt && config.getConfig().mqtt.retries) {
-        retries = config.getConfig().mqtt.retries;
+    if (mqttConfig.retries) {
+        retries = mqttConfig.retries;
     } else {
         retries = constants.MQTT_DEFAULT_RETRIES;
     }
-    if (config.getConfig() && config.getConfig().mqtt && config.getConfig().mqtt.retrytime) {
-        retryTime = config.getConfig().mqtt.retryTime;
+    if (mqttConfig.retrytime) {
+        retryTime = mqttConfig.retryTime;
     } else {
         retryTime = constants.MQTT_DEFAULT_RETRY_TIME;
     }
@@ -260,7 +264,7 @@ function start(callback) {
         }
         isConnecting = true;
         mqttClient = mqtt.connect(
-            'mqtt://' + config.getConfig().mqtt.host + ':' + config.getConfig().mqtt.port,
+            options.protocol + '://' + config.getConfig().mqtt.host + ':' + config.getConfig().mqtt.port,
             options
         );
         isConnecting = false;

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -248,7 +248,7 @@ function start(callback) {
     } else {
         retries = constants.MQTT_DEFAULT_RETRIES;
     }
-    if (mqttConfig.retrytime) {
+    if (mqttConfig.retryTime) {
         retryTime = mqttConfig.retryTime;
     } else {
         retryTime = constants.MQTT_DEFAULT_RETRY_TIME;

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -113,8 +113,8 @@ function processEnvironmentVariables() {
         httpVariables = ['IOTA_HTTP_HOST', 'IOTA_HTTP_PORT', 'IOTA_HTTP_TIMEOUT', 'IOTA_HTTP_KEY', 'IOTA_HTTP_CERT'];
 
     for (var i = 0; i < environmentVariables.length; i++) {
-        if (process.env[environmentVariables[i]]) {
-            var value = environmentVariables[i];
+        var value = process.env[environmentVariables[i]];
+        if (value) {
             if (environmentVariables[i].endsWith('USERNAME') || environmentVariables[i].endsWith('PASSWORD')) {
                 value = '********';
             }

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -38,8 +38,13 @@ function anyIsSet(variableSet) {
 
 function processEnvironmentVariables() {
     var environmentVariables = [
+            'IOTA_MQTT_PROTOCOL',
             'IOTA_MQTT_HOST',
             'IOTA_MQTT_PORT',
+            'IOTA_MQTT_CA',
+            'IOTA_MQTT_CERT',
+            'IOTA_MQTT_KEY',
+            'IOTA_MQTT_REJECT_UNAUTHORIZED',
             'IOTA_MQTT_USERNAME',
             'IOTA_MQTT_PASSWORD',
             'IOTA_MQTT_QOS',
@@ -59,20 +64,24 @@ function processEnvironmentVariables() {
             'IOTA_HTTP_HOST',
             'IOTA_HTTP_PORT',
             'IOTA_HTTP_TIMEOUT',
-            'IOTA_HTTP_PRIVATE_KEY',
-            'IOTA_HTTP_CERTIFICATE'
+            'IOTA_HTTP_KEY',
+            'IOTA_HTTP_CERT'
         ],
         mqttVariables = [
+            'IOTA_MQTT_PROTOCOL',
             'IOTA_MQTT_HOST',
             'IOTA_MQTT_PORT',
+            'IOTA_MQTT_CA',
+            'IOTA_MQTT_CERT',
+            'IOTA_MQTT_KEY',
+            'IOTA_MQTT_REJECT_UNAUTHORIZED',
             'IOTA_MQTT_USERNAME',
             'IOTA_MQTT_PASSWORD',
             'IOTA_MQTT_QOS',
             'IOTA_MQTT_RETAIN',
             'IOTA_MQTT_RETRIES',
             'IOTA_MQTT_RETRY_TIME',
-            'IOTA_MQTT_KEEPALIVE',
-            'IOTA_MQTT_REJECT_UNAUTHORIZED'
+            'IOTA_MQTT_KEEPALIVE'
         ],
         amqpVariables = [
             'IOTA_AMQP_HOST',
@@ -85,7 +94,7 @@ function processEnvironmentVariables() {
             'IOTA_AMQP_RETRIES',
             'IOTA_AMQP_RETRY_TIME'
         ],
-        httpVariables = ['IOTA_HTTP_HOST', 'IOTA_HTTP_PORT', 'IOTA_HTTP_TIMEOUT'];
+        httpVariables = ['IOTA_HTTP_HOST', 'IOTA_HTTP_PORT', 'IOTA_HTTP_TIMEOUT', 'IOTA_HTTP_KEY', 'IOTA_HTTP_CERT'];
 
     for (var i = 0; i < environmentVariables.length; i++) {
         if (process.env[environmentVariables[i]]) {
@@ -101,12 +110,33 @@ function processEnvironmentVariables() {
         config.mqtt = {};
     }
 
+    if (process.env.IOTA_MQTT_PROTOCOL) {
+        config.mqtt.protocol = process.env.IOTA_MQTT_PROTOCOL;
+    }
+
     if (process.env.IOTA_MQTT_HOST) {
         config.mqtt.host = process.env.IOTA_MQTT_HOST;
     }
 
     if (process.env.IOTA_MQTT_PORT) {
         config.mqtt.port = process.env.IOTA_MQTT_PORT;
+    }
+
+    if (process.env.IOTA_MQTT_CA) {
+        config.mqtt.ca = process.env.IOTA_MQTT_CA;
+    }
+
+    if (process.env.IOTA_MQTT_CERT) {
+        config.mqtt.cert = process.env.IOTA_MQTT_CERT;
+    }
+
+    if (process.env.IOTA_MQTT_KEY) {
+        config.mqtt.key = process.env.IOTA_MQTT_KEY;
+    }
+    // Since default is true, need to be able accept "false" as
+    // a valid Environment variable
+    if (process.env.IOTA_MQTT_REJECT_UNAUTHORIZED !== undefined) {
+        config.mqtt.rejectUnauthorized = process.env.IOTA_MQTT_REJECT_UNAUTHORIZED.trim().toLowerCase() === 'true';
     }
 
     if (process.env.IOTA_MQTT_USERNAME) {
@@ -122,7 +152,7 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_MQTT_RETAIN) {
-        config.mqtt.retain = process.env.IOTA_MQTT_RETAIN === 'true';
+        config.mqtt.retain = process.env.IOTA_MQTT_RETAIN.trim().toLowerCase() === 'true';
     }
 
     if (process.env.IOTA_MQTT_RETRIES) {
@@ -135,9 +165,6 @@ function processEnvironmentVariables() {
 
     if (process.env.IOTA_MQTT_KEEPALIVE) {
         config.mqtt.keepalive = process.env.IOTA_MQTT_KEEPALIVE;
-    }
-    if (process.env.IOTA_MQTT_REJECT_UNAUTHORIZED !== undefined) {
-        config.mqtt.rejectUnauthorized = process.env.IOTA_MQTT_REJECT_UNAUTHORIZED;
     }
 
     if (anyIsSet(amqpVariables)) {
@@ -170,7 +197,7 @@ function processEnvironmentVariables() {
 
     if (process.env.IOTA_AMQP_DURABLE) {
         config.amqp.options = {};
-        config.amqp.options.durable = process.env.IOTA_AMQP_DURABLE === 'true';
+        config.amqp.options.durable = process.env.IOTA_AMQP_DURABLE.trim().toLowerCase() === 'true';
     }
 
     if (process.env.IOTA_AMQP_RETRIES) {
@@ -197,12 +224,12 @@ function processEnvironmentVariables() {
         config.http.timeout = process.env.IOTA_HTTP_TIMEOUT;
     }
 
-    if (process.env.IOTA_HTTP_PRIVATE_KEY) {
-        config.http.privateKey = process.env.IOTA_HTTP_PRIVATE_KEY;
+    if (process.env.IOTA_HTTP_KEY) {
+        config.http.key = process.env.IOTA_HTTP_KEY;
     }
 
-    if (process.env.IOTA_HTTP_CERTIFICATE) {
-        config.http.certificate = process.env.IOTA_HTTP_CERTIFICATE;
+    if (process.env.IOTA_HTTP_CERT) {
+        config.http.cert = process.env.IOTA_HTTP_CERT;
     }
 }
 

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -114,11 +114,11 @@ function processEnvironmentVariables() {
 
     for (var i = 0; i < environmentVariables.length; i++) {
         if (process.env[environmentVariables[i]]) {
-            logger.info(
-                'Setting %s to environment value: %s',
-                environmentVariables[i],
-                process.env[environmentVariables[i]]
-            );
+            var value = environmentVariables[i];
+            if (environmentVariables[i].endsWith('USERNAME') || environmentVariables[i].endsWith('PASSWORD')) {
+                value = '********';
+            }
+            logger.info('Setting %s to environment value: %s', environmentVariables[i], value);
         }
     }
 

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -44,7 +44,7 @@ function anyIsSet(variableSet) {
  */
 function fileExists(path) {
     try {
-        var stats = fs.statSync(path);
+        fs.statSync(path);
         logger.debug(path + ' - File exists.');
     } catch (e) {
         logger.fatal(path + ' - File does not exist.');

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -58,7 +58,9 @@ function processEnvironmentVariables() {
             'IOTA_AMQP_RETRY_TIME',
             'IOTA_HTTP_HOST',
             'IOTA_HTTP_PORT',
-            'IOTA_HTTP_TIMEOUT'
+            'IOTA_HTTP_TIMEOUT',
+            'IOTA_HTTP_PRIVATE_KEY',
+            'IOTA_HTTP_CERTIFICATE'
         ],
         mqttVariables = [
             'IOTA_MQTT_HOST',
@@ -69,7 +71,8 @@ function processEnvironmentVariables() {
             'IOTA_MQTT_RETAIN',
             'IOTA_MQTT_RETRIES',
             'IOTA_MQTT_RETRY_TIME',
-            'IOTA_MQTT_KEEPALIVE'
+            'IOTA_MQTT_KEEPALIVE',
+            'IOTA_MQTT_REJECT_UNAUTHORIZED'
         ],
         amqpVariables = [
             'IOTA_AMQP_HOST',
@@ -133,6 +136,9 @@ function processEnvironmentVariables() {
     if (process.env.IOTA_MQTT_KEEPALIVE) {
         config.mqtt.keepalive = process.env.IOTA_MQTT_KEEPALIVE;
     }
+    if (process.env.IOTA_MQTT_REJECT_UNAUTHORIZED !== undefined) {
+        config.mqtt.rejectUnauthorized = process.env.IOTA_MQTT_REJECT_UNAUTHORIZED;
+    }
 
     if (anyIsSet(amqpVariables)) {
         config.amqp = {};
@@ -189,6 +195,14 @@ function processEnvironmentVariables() {
 
     if (process.env.IOTA_HTTP_TIMEOUT) {
         config.http.timeout = process.env.IOTA_HTTP_TIMEOUT;
+    }
+
+    if (process.env.IOTA_HTTP_PRIVATE_KEY) {
+        config.http.privateKey = process.env.IOTA_HTTP_PRIVATE_KEY;
+    }
+
+    if (process.env.IOTA_HTTP_CERTIFICATE) {
+        config.http.certificate = process.env.IOTA_HTTP_CERTIFICATE;
     }
 }
 

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -24,6 +24,7 @@
 'use strict';
 
 var config = {},
+    fs = require('fs'),
     logger = require('logops');
 
 function anyIsSet(variableSet) {
@@ -34,6 +35,21 @@ function anyIsSet(variableSet) {
     }
 
     return false;
+}
+
+/**
+ * For a parameter pointing to a file, check the file exists
+ *
+ * @param {string} path        Path to the file
+ */
+function fileExists(path) {
+    try {
+        var stats = fs.statSync(path);
+        logger.debug(path + ' - File exists.');
+    } catch (e) {
+        logger.fatal(path + ' - File does not exist.');
+        throw Error(path + ' - File does not exist.');
+    }
 }
 
 function processEnvironmentVariables() {
@@ -123,14 +139,17 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_MQTT_CA) {
+        fileExists(process.env.IOTA_MQTT_CA);
         config.mqtt.ca = process.env.IOTA_MQTT_CA;
     }
 
     if (process.env.IOTA_MQTT_CERT) {
+        fileExists(process.env.IOTA_MQTT_CERT);
         config.mqtt.cert = process.env.IOTA_MQTT_CERT;
     }
 
     if (process.env.IOTA_MQTT_KEY) {
+        fileExists(process.env.IOTA_MQTT_KEY);
         config.mqtt.key = process.env.IOTA_MQTT_KEY;
     }
     // Since default is true, need to be able accept "false" as
@@ -225,10 +244,12 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_HTTP_KEY) {
+        fileExists(process.env.IOTA_HTTP_KEY);
         config.http.key = process.env.IOTA_HTTP_KEY;
     }
 
     if (process.env.IOTA_HTTP_CERT) {
+        fileExists(process.env.IOTA_HTTP_CERT);
         config.http.cert = process.env.IOTA_HTTP_CERT;
     }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",
-    "sinon": "^9.0.1",
     "underscore": "1.9.1"
   },
   "devDependencies": {
@@ -63,6 +62,7 @@
     "textlint-rule-terminology": "~1.1.30",
     "textlint-rule-write-good": "~1.6.2",
     "should": "13.2.3",
+    "sinon": "~9.0.1",
     "timekeeper": "2.1.2",
     "watch": "~1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",
+    "sinon": "^9.0.1",
     "underscore": "1.9.1"
   },
   "devDependencies": {

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -23,19 +23,22 @@
 'use strict';
 
 var config = require('../../lib/configService'),
-    iotAgentConfig = require('../config-test.js');
+    iotAgentConfig = require('../config-test.js'),
+    fs = require('fs'),
+    sinon = require('sinon');
 
 describe('Startup tests', function() {
     describe('When the MQTT transport is started with environment variables', function() {
         beforeEach(function() {
+            sinon.stub(fs, 'statSync');
             process.env.IOTA_MQTT_HOST = '127.0.0.1';
             process.env.IOTA_MQTT_PORT = '1883';
             process.env.IOTA_MQTT_USERNAME = 'usermqtt';
             process.env.IOTA_MQTT_PASSWORD = 'passmqtt';
             process.env.IOTA_MQTT_PROTOCOL = 'xxx';
-            //process.env.IOTA_MQTT_CA = '/mqtt/xxx/ca';
-            //process.env.IOTA_MQTT_CERT = '/mqtt/xxx/cert.pem';
-            //process.env.IOTA_MQTT_KEY = '/mqtt/xxx/key.pem';
+            process.env.IOTA_MQTT_CA = '/mqtt/xxx/ca';
+            process.env.IOTA_MQTT_CERT = '/mqtt/xxx/cert.pem';
+            process.env.IOTA_MQTT_KEY = '/mqtt/xxx/key.pem';
             process.env.IOTA_MQTT_REJECT_UNAUTHORIZED = 'true';
             process.env.IOTA_MQTT_QOS = '0';
             process.env.IOTA_MQTT_RETAIN = 'false';
@@ -45,6 +48,7 @@ describe('Startup tests', function() {
         });
 
         afterEach(function() {
+            fs.statSync.restore();
             delete process.env.IOTA_MQTT_PROTOCOL;
             delete process.env.IOTA_MQTT_HOST;
             delete process.env.IOTA_MQTT_PORT;
@@ -67,9 +71,9 @@ describe('Startup tests', function() {
             config.getConfig().mqtt.port.should.equal('1883');
             config.getConfig().mqtt.username.should.equal('usermqtt');
             config.getConfig().mqtt.password.should.equal('passmqtt');
-            //config.getConfig().mqtt.ca.should.equal('/mqtt/xxx/ca');
-            //config.getConfig().mqtt.cert.should.equal( '/mqtt/xxx/cert.pem');
-            //config.getConfig().mqtt.key.should.equal('/mqtt/xxx/key.pem');
+            config.getConfig().mqtt.ca.should.equal('/mqtt/xxx/ca');
+            config.getConfig().mqtt.cert.should.equal('/mqtt/xxx/cert.pem');
+            config.getConfig().mqtt.key.should.equal('/mqtt/xxx/key.pem');
             config.getConfig().mqtt.rejectUnauthorized.should.equal(true);
             config.getConfig().mqtt.qos.should.equal('0');
             config.getConfig().mqtt.retain.should.equal(false);
@@ -122,14 +126,16 @@ describe('Startup tests', function() {
 
     describe('When the HTTP transport is started with environment variables', function() {
         beforeEach(function() {
+            sinon.stub(fs, 'statSync');
             process.env.IOTA_HTTP_HOST = 'localhost';
             process.env.IOTA_HTTP_PORT = '2222';
             process.env.IOTA_HTTP_TIMEOUT = '5';
-            //process.env.IOTA_HTTP_KEY = '/http/bbb/key.pem';
-            //process.env.IOTA_HTTP_CERT = '/http/bbb/cert.pem';
+            process.env.IOTA_HTTP_KEY = '/http/bbb/key.pem';
+            process.env.IOTA_HTTP_CERT = '/http/bbb/cert.pem';
         });
 
         afterEach(function() {
+            fs.statSync.restore();
             delete process.env.IOTA_HTTP_HOST;
             delete process.env.IOTA_HTTP_PORT;
             delete process.env.IOTA_HTTP_TIMEOUT;
@@ -142,8 +148,8 @@ describe('Startup tests', function() {
             config.getConfig().http.host.should.equal('localhost');
             config.getConfig().http.port.should.equal('2222');
             config.getConfig().http.timeout.should.equal('5');
-            //config.getConfig().http.key.should.equal('/http/bbb/key.pem');
-            //config.getConfig().http.cert.should.equal('/http/bbb/cert.pem');
+            config.getConfig().http.key.should.equal('/http/bbb/key.pem');
+            config.getConfig().http.cert.should.equal('/http/bbb/cert.pem');
             done();
         });
     });

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -21,44 +21,130 @@
  * please contact with::[contacto@tid.es]
  */
 'use strict';
-var iotagentUl = require('../../'),
-    config = require('../../lib/configService'),
+
+var config = require('../../lib/configService'),
     iotAgentConfig = require('../config-test.js');
 
 describe('Startup tests', function() {
-    describe('When the IoT Agent is started with environment variables', function() {
+    describe('When the MQTT transport is started with environment variables', function() {
         beforeEach(function() {
             process.env.IOTA_MQTT_HOST = '127.0.0.1';
             process.env.IOTA_MQTT_PORT = '1883';
             process.env.IOTA_MQTT_USERNAME = 'usermqtt';
             process.env.IOTA_MQTT_PASSWORD = 'passmqtt';
-            process.env.IOTA_HTTP_HOST = 'localhost';
-            process.env.IOTA_HTTP_PORT = '2222';
+            process.env.IOTA_MQTT_PROTOCOL = 'xxx';
+            //process.env.IOTA_MQTT_CA = '/mqtt/xxx/ca';
+            //process.env.IOTA_MQTT_CERT = '/mqtt/xxx/cert.pem';
+            //process.env.IOTA_MQTT_KEY = '/mqtt/xxx/key.pem';
+            process.env.IOTA_MQTT_REJECT_UNAUTHORIZED = 'true';
+            process.env.IOTA_MQTT_QOS = '0';
+            process.env.IOTA_MQTT_RETAIN = 'false';
+            process.env.IOTA_MQTT_RETRIES = '2';
+            process.env.IOTA_MQTT_RETRY_TIME = '5';
+            process.env.IOTA_MQTT_KEEPALIVE = '0';
         });
 
         afterEach(function() {
+            delete process.env.IOTA_MQTT_PROTOCOL;
             delete process.env.IOTA_MQTT_HOST;
             delete process.env.IOTA_MQTT_PORT;
+            delete process.env.IOTA_MQTT_CA;
+            delete process.env.IOTA_MQTT_CERT;
+            delete process.env.IOTA_MQTT_KEY;
+            delete process.env.IOTA_MQTT_REJECT_UNAUTHORIZED;
             delete process.env.IOTA_MQTT_USERNAME;
             delete process.env.IOTA_MQTT_PASSWORD;
+            delete process.env.IOTA_MQTT_QOS;
+            delete process.env.IOTA_MQTT_RETAIN;
+            delete process.env.IOTA_MQTT_RETRIES;
+            delete process.env.IOTA_MQTT_RETRY_TIME;
+            delete process.env.IOTA_MQTT_KEEPALIVE;
+        });
+
+        it('should load the MQTT environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().mqtt.host.should.equal('127.0.0.1');
+            config.getConfig().mqtt.port.should.equal('1883');
+            config.getConfig().mqtt.username.should.equal('usermqtt');
+            config.getConfig().mqtt.password.should.equal('passmqtt');
+            //config.getConfig().mqtt.ca.should.equal('/mqtt/xxx/ca');
+            //config.getConfig().mqtt.cert.should.equal( '/mqtt/xxx/cert.pem');
+            //config.getConfig().mqtt.key.should.equal('/mqtt/xxx/key.pem');
+            config.getConfig().mqtt.rejectUnauthorized.should.equal(true);
+            config.getConfig().mqtt.qos.should.equal('0');
+            config.getConfig().mqtt.retain.should.equal(false);
+            config.getConfig().mqtt.retries.should.equal('2');
+            config.getConfig().mqtt.retryTime.should.equal('5');
+            config.getConfig().mqtt.keepalive.should.equal('0');
+            done();
+        });
+    });
+
+    describe('When the AMQP transport is started with environment variables', function() {
+        beforeEach(function() {
+            process.env.IOTA_AMQP_HOST = 'localhost';
+            process.env.IOTA_AMQP_PORT = '9090';
+            process.env.IOTA_AMQP_USERNAME = 'useramqp';
+            process.env.IOTA_AMQP_PASSWORD = 'passamqp';
+            process.env.IOTA_AMQP_EXCHANGE = 'xxx';
+            process.env.IOTA_AMQP_QUEUE = '0';
+            process.env.IOTA_AMQP_DURABLE = 'true';
+            process.env.IOTA_AMQP_RETRIES = '0';
+            process.env.IOTA_AMQP_RETRY_TIME = '5';
+        });
+
+        afterEach(function() {
+            delete process.env.IOTA_AMQP_HOST;
+            delete process.env.IOTA_AMQP_PORT;
+            delete process.env.IOTA_AMQP_USERNAME;
+            delete process.env.IOTA_AMQP_PASSWORD;
+            delete process.env.IOTA_AMQP_EXCHANGE;
+            delete process.env.IOTA_AMQP_QUEUE;
+            delete process.env.IOTA_AMQP_DURABLE;
+            delete process.env.IOTA_AMQP_RETRIES;
+            delete process.env.IOTA_AMQP_RETRY_TIME;
+        });
+
+        it('should load the AMQP environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().amqp.host.should.equal('localhost');
+            config.getConfig().amqp.port.should.equal('9090');
+            config.getConfig().amqp.username.should.equal('useramqp');
+            config.getConfig().amqp.password.should.equal('passamqp');
+            config.getConfig().amqp.exchange.should.equal('xxx');
+            config.getConfig().amqp.queue.should.equal('0');
+            config.getConfig().amqp.options.durable.should.equal(true);
+            config.getConfig().amqp.retries.should.equal('0');
+            config.getConfig().amqp.retryTime.should.equal('5');
+            done();
+        });
+    });
+
+    describe('When the HTTP transport is started with environment variables', function() {
+        beforeEach(function() {
+            process.env.IOTA_HTTP_HOST = 'localhost';
+            process.env.IOTA_HTTP_PORT = '2222';
+            process.env.IOTA_HTTP_TIMEOUT = '5';
+            //process.env.IOTA_HTTP_KEY = '/http/bbb/key.pem';
+            //process.env.IOTA_HTTP_CERT = '/http/bbb/cert.pem';
+        });
+
+        afterEach(function() {
             delete process.env.IOTA_HTTP_HOST;
             delete process.env.IOTA_HTTP_PORT;
+            delete process.env.IOTA_HTTP_TIMEOUT;
+            delete process.env.IOTA_HTTP_KEY;
+            delete process.env.IOTA_HTTP_CERT;
         });
 
-        afterEach(function(done) {
-            iotagentUl.stop(done);
-        });
-
-        it('should load the environment variables in the internal configuration', function(done) {
-            iotagentUl.start(iotAgentConfig, function(error) {
-                config.getConfig().mqtt.host.should.equal('127.0.0.1');
-                config.getConfig().mqtt.port.should.equal('1883');
-                config.getConfig().mqtt.username.should.equal('usermqtt');
-                config.getConfig().mqtt.password.should.equal('passmqtt');
-                config.getConfig().http.host.should.equal('localhost');
-                config.getConfig().http.port.should.equal('2222');
-                done();
-            });
+        it('should load the HTTP environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().http.host.should.equal('localhost');
+            config.getConfig().http.port.should.equal('2222');
+            config.getConfig().http.timeout.should.equal('5');
+            //config.getConfig().http.key.should.equal('/http/bbb/key.pem');
+            //config.getConfig().http.cert.should.equal('/http/bbb/cert.pem');
+            done();
         });
     });
 });


### PR DESCRIPTION
- Allow HTTP endpoint to be configured with a cert and a private key
- Allow self signed certs when using MQTT with SSL
- Update documentation