### PR TITLE
fix: change order of arguments to correspond with message

### DIFF
--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -147,8 +147,8 @@ function generateCommandExecution(apiKey, device, attribute) {
     config.getLogger().debug(
         context,
         'Sending command execution to device [%s] with apikey [%s] and payload [%s] ',
-        apiKey,
         device.id,
+        apiKey,
         payload
     );
     var commandTopic = '/' + apiKey + '/' + device.id + '/cmd';


### PR DESCRIPTION
API key and device id was mixed up in logged message