### PR TITLE
Fix: Log always write the same correlator id and transaction id

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,3 @@
 Set Nodejs 10 as minimum version in packages.json (effectively removing Nodev8 from supported versions)
+
+Fix: log always writing the same correlator id and transaction id (issue #326)

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -26,6 +26,7 @@
 'use strict';
 
 var iotAgentLib = require('iotagent-node-lib'),
+    regenerateTransid = iotAgentLib.regenerateTransid,
     config = require('./configService'),
     transportSelector = require('./transportSelector'),
     intoTrans = iotAgentLib.intoTrans,
@@ -318,6 +319,7 @@ function messageHandler(topic, message, protocol) {
  * @param {Object} message      AMQP message body (Object or Buffer, depending on the value).
  */
 function amqpMessageHandler(topic, message) {
+    regenerateTransid(topic);
     messageHandler(topic, message, 'AMQP');
 }
 
@@ -329,6 +331,7 @@ function amqpMessageHandler(topic, message) {
  * @param {Object} message      MQTT message body (Object or Buffer, depending on the value).
  */
 function mqttMessageHandler(topic, message) {
+    regenerateTransid(topic);
     config.getLogger().debug(context, 'message topic: %s', topic);
     messageHandler(topic, message, 'MQTT');
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "git://github.com/DeepshikhaNEC/iotagent-node-lib.git#nodelib-issue/426",
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/DeepshikhaNEC/iotagent-node-lib.git#nodelib-issue/426",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",


### PR DESCRIPTION
Fixed issue #326 for iotagent-ul that logs always write the same correlator id and transaction id.