### PR TITLE
Fix dead links false positives on Markdown linter

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -185,13 +185,6 @@
       "weasel": false,
       "so": false,
       "thereIs" :false
-    },
-    "no-dead-link": {
-       "ignoreRedirects": true,
-       "ignore": [
-          "mailto:*",
-          "https://coveralls.io/**"
-      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "sinon": "~9.0.2",
     "textlint": "~11.7.6",
     "textlint-rule-common-misspellings": "~1.0.1",
-    "textlint-rule-no-dead-link": "~4.7.0",
     "textlint-rule-terminology": "~2.1.4",
     "textlint-rule-write-good": "~1.6.2",
     "timekeeper": "2.2.0",


### PR DESCRIPTION
- Removed textlint no-dead-link from .textlintrc
- Removed textlint-rule-no-dead-link from package.json

Related with https://github.com/telefonicaid/iotagent-json/pull/515#issuecomment-736355544