### PR TITLE
Replace checkNgsi2 with isCurrentNgsi

### DIFF
--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -56,7 +56,7 @@ function guessType(attribute, device) {
     }
 
     if (attribute === constants.TIMESTAMP_ATTRIBUTE) {
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             return constants.TIMESTAMP_TYPE_NGSI2;
         }
         return constants.TIMESTAMP_TYPE;

--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -266,7 +266,7 @@ function manageConfiguration(apiKey, deviceId, device, objMessage, sendFunction,
     }
 
     function extractAttributes(results, callback) {
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             callback(null, results);
         } else if (
             results.contextResponses &&
@@ -324,7 +324,7 @@ function createConfigurationNotification(results) {
     const configurations = {};
     const now = new Date();
 
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         for (var att in results) {
             configurations[att] = results[att].value;
         }


### PR DESCRIPTION
Related https://github.com/telefonicaid/iotagent-node-lib/issues/963

Note: the `isCurrentNgsi()` can be removed once NGSI-v1 is dropped.