### PR TITLE
Fully Remove Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          # FIXME: node v10 has been deprecated, but we are going to keep its regression for a while
+          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 8 End-of-Life
+- Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-
+- Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 8 End-of-Life
+- Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@
 # For those usages not covered by the GNU Affero General Public License
 # please contact with: [daniel.moranjimenez@telefonica.com]
 
-ARG NODE_VERSION=10
+ARG NODE_VERSION=12
 ARG GITHUB_ACCOUNT=telefonicaid
 ARG GITHUB_REPOSITORY=iotagent-ul
 ARG DOWNLOAD=latest

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -16,7 +16,7 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v4 in iotagent-ul 1.8.0 (finally removed in 1.9.0)
 -   Support to Node.js v6 in iotagent-ul 1.9.0 (finally removed in 1.10.0)
 -   Support to Node.js v8 in iotagent-ul 1.13.0 (finally removed in 1.14.0)
--   Support to Node.js v10 in iotagent-ul 1.16.0
+-   Support to Node.js v10 in iotagent-ul 1.16.0 (finally removed in 1.17.0)
 
 The use of Node.js v12 is highly recommended.
 
@@ -41,7 +41,7 @@ The following table provides information about the last iotagent-ul version supp
 | **Removed feature**    | **Last iotagent-ul version supporting feature**   | **That version release date** |
 | ---------------------- | ------------------------------------------------- | ----------------------------- |
 | NGSIv1 API             | Not yet defined                                   | Not yet defined               |
-| Support to Node.js v4  | 1.8.0                                             | December 19th, 2018                 |
-| Support to Node.js v6  | 1.9.0                                             | May 22nd, 2019                      |
-| Support to Node.js v8  | 1.13.0                                            | April 7th, 2020                    |
-| Support to Node.js v10 | Not defined but it will completed before May 2021 | Not yet defined               |
+| Support to Node.js v4  | 1.8.0                                             | December 19th, 2018           |
+| Support to Node.js v6  | 1.9.0                                             | May 22nd, 2019                |
+| Support to Node.js v8  | 1.13.0                                            | April 7th, 2020               |
+| Support to Node.js v10 | 1.16.0                                            | Not yet defined               |

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -44,4 +44,4 @@ The following table provides information about the last iotagent-ul version supp
 | Support to Node.js v4  | 1.8.0                                             | December 19th, 2018           |
 | Support to Node.js v6  | 1.9.0                                             | May 22nd, 2019                |
 | Support to Node.js v8  | 1.13.0                                            | April 7th, 2020               |
-| Support to Node.js v10 | 1.16.0                                            | Not yet defined               |
+| Support to Node.js v10 | 1.16.0                                            | February 18th, 2021               |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "lib/iotagent-ul",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",


### PR DESCRIPTION
With the recent release, Node 10 can be fully removed for the next release. No rush to merge this, just raising it whilst I remember to do it.