### PR TITLE
 Step: 1.16.0 -> 1.16.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iotagent-ul",
   "license": "AGPL-3.0-only",
   "description": "IoT Agent for the Ultrlight 2.0 protocol",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "homepage": "https://github.com/telefonicaid/iotagent-ul",
   "author": {
     "name": "Daniel Moran",
@@ -39,7 +39,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "2.15.0",
+    "iotagent-node-lib": "2.15.1",
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",

--- a/rpm/SPECS/iotaul.spec
+++ b/rpm/SPECS/iotaul.spec
@@ -170,6 +170,9 @@ fi
 %{_install_dir}
 
 %changelog
+* Tue Apr 6 2021 Alvaro Vega <alvaro.vegagarcia@telefonica.com> 1.16.1
+- Upgrade iotagent-node-lib dependency from 2.15.0 to 2.15.1
+
 * Thu Feb 18 2021 Alvaro Vega <alvaro.vegagarcia@telefonica.com> 1.16.0
 - Fix: Set 60 seconds for default mqtt keepalive option (#370)
 - Upgrade iotagent-node-lib dependency from 2.14.0 to 2.15.0


### PR DESCRIPTION
relies on telefonicaid/iotagent-node-lib#1015