### PR TITLE
use expressionLanguage from group if not defined in device

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: use expressionLanguage defined in group is not defined at device level (iota-node-lib#1027)
 - (Only tests) Fix: ensure service of groups, device and commands is stored in mongo in lowercase (iota-node-lib#1023)
 - Add: MQTT options `clean` and `clientId` (env vars IOTA_MQTT_CLEA and IOTA_MQTT_CLIENT_ID) (#371)
 - Fix: missing content-type: text/plain header in the request sent to device command endpoint (HTTP transport)

--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -156,6 +156,10 @@ function mergeDeviceWithConfiguration(deviceData, configuration, callback) {
         }
     }
 
+    if (configuration && configuration.expressionLanguage && deviceData.expressionLanguage === undefined) {
+        deviceData.expressionLanguage = configuration.expressionLanguage;
+    }
+
     callback(null, deviceData);
 }
 


### PR DESCRIPTION
related with https://github.com/telefonicaid/iotagent-node-lib/pull/1029