### PR TITLE
Fix: Processing configurations subscriptions in NGSIv2 

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Fix: Processing configurations subscriptions in NGSIv2 (#496)

--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -359,8 +359,16 @@ function createConfigurationNotification(results) {
     const now = new Date();
 
     if (iotAgentLib.configModule.isCurrentNgsi()) {
-        for (var att in results) {
-            configurations[att] = results[att].value;
+        // If it is the result of a subscription, results is an array
+        if (Array.isArray(results)){
+            for (let i = 0; i < results.length; i++) {
+                configurations[results[i].name] = results[i].value;
+            }
+        }
+        else {
+            for (var att in results) {
+                configurations[att] = results[att].value;
+            }
         }
     } else {
         for (let i = 0; i < results.length; i++) {


### PR DESCRIPTION
PR to fix the problems reported here https://github.com/telefonicaid/iotagent-ul/pull/493#discussion_r654531005

The problem is in NGSIv2, the value of results is different depending if it is triggered by: 
- Context Request (configuration|pollingInterval|publishInterval), having the following value: `{"type":"number","value":"200","metadata":{}},"publishInterval":{"type":"number","value":"80","metadata":{}}}`

- Context Notification (subscription|pollingInterval|publishInterval), having the following value: `[{"type":"string","value":"60","name":"pollingInterval"},{"type":"number","value":"600","name":"publishInterval"}]`