### PR TITLE
Update NGSI-V2 tests (same as PR #493)

### DIFF
--- a/test/unit/ngsiv2/HTTP_commands_test.js
+++ b/test/unit/ngsiv2/HTTP_commands_test.js
@@ -138,4 +138,129 @@ describe('HTTP: Commands', function () {
             });
         });
     });
+
+    describe('When a command arrive to the Agent and the device answers with an error', function () {
+        const commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand1.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus1.json')
+                )
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice'
+                )
+                .reply(204);
+
+            mockedClientServer = nock('http://localhost:9876')
+                .post('/command', function (body) {
+                    return body === 'MQTT_2@PING|data=22';
+                })
+                .reply(200, 'MQTT_2@PING|ping ERROR, Command error');
+        });
+
+        it('should update the status in the Context Broker', function (done) {
+            request(commandOptions, function (error, response, body) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a command arrive with a wrong endpoint', function () {
+
+        const commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommandWrongEndpoint.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        const provisionWrongEndpoint = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionCommandWrongEndpoint.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function (done) {
+            nock.cleanAll();
+
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/registrations')
+                .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities?options=upsert')
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Wrong%20MQTT%20Device/attrs?type=AnMQTTDevice'
+                )
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Wrong%20MQTT%20Device/attrs?type=AnMQTTDevice', function (body) {
+                        return body.PING_status.value === 'ERROR';
+                })
+                .reply(204);
+
+            request(provisionWrongEndpoint, function (error, response, body) {
+                setTimeout(function () {
+                    done();
+                }, 50);
+            });
+        });
+
+        it('should return a 204 OK without errors', function (done) {
+            request(commandOptions, function (error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+
+        it('should update the status in the Context Broker', function (done) {
+            request(commandOptions, function (error, response, body) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
 });

--- a/test/unit/ngsiv2/configurationsMqtt-test.js
+++ b/test/unit/ngsiv2/configurationsMqtt-test.js
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ */
+
+/* eslint-disable no-unused-vars */
+
+const iotagentMqtt = require('../../../');
+const mqtt = require('mqtt');
+const config = require('./config-test.js');
+const nock = require('nock');
+const should = require('should');
+const iotAgentLib = require('iotagent-node-lib');
+const async = require('async');
+const request = require('request');
+const utils = require('../../utils');
+let contextBrokerMock;
+let oldConfigurationFlag;
+let mqttClient;
+
+describe('MQTT Transport binding: configurations', function () {
+    beforeEach(function (done) {
+        const provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/configurationRetrieval/provisionDeviceWithConfiguration.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        config.logLevel = 'INFO';
+
+        nock.cleanAll();
+
+        mqttClient = mqtt.connect('mqtt://' + config.mqtt.host, {
+            keepalive: 0,
+            connectTimeout: 60 * 60 * 1000
+        });
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartgondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        oldConfigurationFlag = config.configRetrieval;
+        config.configRetrieval = true;
+
+        iotagentMqtt.start(config, function () {
+            request(provisionOptions, function (error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function (done) {
+        config.configRetrieval = oldConfigurationFlag;
+
+        nock.cleanAll();
+        mqttClient.end();
+
+        async.series([iotAgentLib.clearAll, iotagentMqtt.stop], done);
+    });
+
+    describe('When a configuration request is received in the topic "/{{apikey}}/{{deviceid}}/configuration/commands"', function () {
+        const values = 'configuration|pollingInterval|publishInterval';
+        let configurationReceived;
+
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .get('/v2/entities/MQTT%20Device%201/attrs?attrs=pollingInterval,publishInterval&type=AnMQTTDevice')
+                .reply(200, utils.readExampleFile('./test/unit/ngsiv2/contextResponses/getConfigurationSuccess.json'));
+
+            mqttClient.subscribe('/1234/MQTT_device_1/configuration/values', null);
+
+            configurationReceived = false;
+        });
+
+        afterEach(function (done) {
+            mqttClient.unsubscribe('/1234/MQTT_device_1/configuration/values', null);
+
+            done();
+        });
+
+        it('should ask the Context Broker for the request attributes', function (done) {
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+
+        it('should return the requested attributes to the client in /1234/MQTT_device_1/configuration/values', function (done) {
+            mqttClient.on('message', function (topic, data) {
+                const result = utils.parseConfigurationResponse(data.toString());
+
+                configurationReceived =
+                    result.pollingInterval &&
+                    result.pollingInterval === '200' &&
+                    result.publishInterval &&
+                    result.publishInterval === '80';
+            });
+
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    configurationReceived.should.equal(true);
+                    done();
+                }, 100);
+            });
+        });
+
+        it('should add the system timestamp in compressed format to the request', function (done) {
+            mqttClient.on('message', function (topic, data) {
+                const result = utils.parseConfigurationResponse(data.toString());
+
+                configurationReceived = result.dt && result.dt.should.match(/^\d{8}T\d{6}Z$/);
+            });
+
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    should.exist(configurationReceived);
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a subscription request is received in the IoT Agent', function () {
+        const values = 'subscription|pollingInterval|publishInterval';
+        let configurationReceived;
+
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/subscriptions',
+                    utils.readExampleFile('./test/unit/ngsiv2/subscriptionRequests/configurationsMqttRequest.json')
+                )
+                .reply(201, null, { Location: '/v2/subscriptions/51c0ac9ed714fb3b37d7d5a8' });
+
+            mqttClient.subscribe('/1234/MQTT_device_1/configuration/values', null);
+
+            configurationReceived = false;
+        });
+
+        afterEach(function (done) {
+            mqttClient.unsubscribe('/1234/MQTT_device_1/configuration/values', null);
+
+            done();
+        });
+
+        it('should create a subscription in the ContextBroker', function (done) {
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+
+        it('should update the values in the MQTT topic when a notification is received', function (done) {
+            const optionsNotify = {
+                url: 'http://localhost:' + config.iota.server.port + '/notify',
+                method: 'POST',
+                json: utils.readExampleFile(
+                    './test/unit/ngsiv2/subscriptionRequests/configurationsMqttNotification.json'
+                ),
+                headers: {
+                    'fiware-service': 'smartgondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+            mqttClient.on('message', function (topic, data) {
+                const result = utils.parseConfigurationResponse(data.toString());
+
+                configurationReceived = result.pollingInterval === '60' && result.publishInterval === '600';
+            });
+
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    request(optionsNotify, function (error, response, body) {
+                        setTimeout(function () {
+                            configurationReceived.should.equal(true);
+                            done();
+                        }, 100);
+                    });
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a configuration request type is other than "configuration" or "subscription"', function () {
+        const values = 'notallowedtype|pollingInterval|publishInterval';
+
+        it('should silently ignore the error (without crashing)', function (done) {
+            mqttClient.publish('/1234/MQTT_device_1/configuration/commands', values, null, function (error) {
+                setTimeout(function () {
+                    done();
+                }, 100);
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/contextRequests/updateCommandWrongEndpoint.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommandWrongEndpoint.json
@@ -1,0 +1,13 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Wrong MQTT Device",
+      "type": "AnMQTTDevice",
+      "PING": {
+          "type": "command",
+          "value": 22
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatusError1.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatusError1.json
@@ -1,0 +1,10 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "ERROR"
+  },
+  "PING_info": {
+    "type": "commandResult",
+    "value": "There was an error in the response of a device to a command [ ]:Error: getaddrinfo ENOTFOUND unexistent.com unexistent.com:80"
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatusError2.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatusError2.json
@@ -1,0 +1,10 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "ERROR"
+  },
+  "PING_info": {
+    "type": "commandResult",
+    "value": "TThere was an error in the response of a device to a command [500]:ping ERROR, Command error"
+  }
+}

--- a/test/unit/ngsiv2/contextResponses/getConfigurationSuccess.json
+++ b/test/unit/ngsiv2/contextResponses/getConfigurationSuccess.json
@@ -1,0 +1,12 @@
+{
+    "pollingInterval": {
+        "type": "number",
+        "value": "200",
+        "metadata": {}
+    },
+    "publishInterval": {
+        "type": "number",
+        "value": "80",
+        "metadata": {}
+    }
+}

--- a/test/unit/ngsiv2/httpBindings-test.js
+++ b/test/unit/ngsiv2/httpBindings-test.js
@@ -248,6 +248,29 @@ describe('HTTP Transport binding: measures', function () {
                 });
             });
         });
+        it('should add a transport to the registered devices', function (done) {
+            const getDeviceOptions = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices/UL_UNPROVISIONED',
+                method: 'GET',
+                headers: {
+                    'fiware-service': 'TestService',
+                    'fiware-servicepath': '/testingPath'
+                }
+            };
+
+            request(getOptions, function (error, response, body) {
+                request(getDeviceOptions, function (error, response, body) {
+                    should.not.exist(error);
+
+                    const parsedBody = JSON.parse(body);
+
+                    response.statusCode.should.equal(200);
+                    should.exist(parsedBody.transport);
+                    parsedBody.transport.should.equal('HTTP');
+                    done();
+                });
+            });
+        });
     });
 
     describe('When a measure with timestamp arrives for a Device, via HTTP GET', function () {

--- a/test/unit/ngsiv2/startup-test.js
+++ b/test/unit/ngsiv2/startup-test.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+const config = require('../../../lib/configService');
+const iotAgentConfig = require('../../config-test.js');
+const fs = require('fs');
+const sinon = require('sinon');
+
+describe('Startup tests', function() {
+    describe('When the MQTT transport is started with environment variables', function() {
+        beforeEach(function() {
+            sinon.stub(fs, 'statSync');
+            process.env.IOTA_MQTT_HOST = '127.0.0.1';
+            process.env.IOTA_MQTT_PORT = '1883';
+            process.env.IOTA_MQTT_USERNAME = 'usermqtt';
+            process.env.IOTA_MQTT_PASSWORD = 'passmqtt';
+            process.env.IOTA_MQTT_PROTOCOL = 'xxx';
+            process.env.IOTA_MQTT_CA = '/mqtt/xxx/ca';
+            process.env.IOTA_MQTT_CERT = '/mqtt/xxx/cert.pem';
+            process.env.IOTA_MQTT_KEY = '/mqtt/xxx/key.pem';
+            process.env.IOTA_MQTT_REJECT_UNAUTHORIZED = 'true';
+            process.env.IOTA_MQTT_QOS = '0';
+            process.env.IOTA_MQTT_RETAIN = 'false';
+            process.env.IOTA_MQTT_RETRIES = '2';
+            process.env.IOTA_MQTT_RETRY_TIME = '5';
+            process.env.IOTA_MQTT_KEEPALIVE = '0';
+        });
+
+        afterEach(function() {
+            fs.statSync.restore();
+            delete process.env.IOTA_MQTT_PROTOCOL;
+            delete process.env.IOTA_MQTT_HOST;
+            delete process.env.IOTA_MQTT_PORT;
+            delete process.env.IOTA_MQTT_CA;
+            delete process.env.IOTA_MQTT_CERT;
+            delete process.env.IOTA_MQTT_KEY;
+            delete process.env.IOTA_MQTT_REJECT_UNAUTHORIZED;
+            delete process.env.IOTA_MQTT_USERNAME;
+            delete process.env.IOTA_MQTT_PASSWORD;
+            delete process.env.IOTA_MQTT_QOS;
+            delete process.env.IOTA_MQTT_RETAIN;
+            delete process.env.IOTA_MQTT_RETRIES;
+            delete process.env.IOTA_MQTT_RETRY_TIME;
+            delete process.env.IOTA_MQTT_KEEPALIVE;
+        });
+
+        it('should load the MQTT environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().mqtt.host.should.equal('127.0.0.1');
+            config.getConfig().mqtt.port.should.equal('1883');
+            config.getConfig().mqtt.username.should.equal('usermqtt');
+            config.getConfig().mqtt.password.should.equal('passmqtt');
+            config.getConfig().mqtt.ca.should.equal('/mqtt/xxx/ca');
+            config.getConfig().mqtt.cert.should.equal('/mqtt/xxx/cert.pem');
+            config.getConfig().mqtt.key.should.equal('/mqtt/xxx/key.pem');
+            config.getConfig().mqtt.rejectUnauthorized.should.equal(true);
+            config.getConfig().mqtt.qos.should.equal('0');
+            config.getConfig().mqtt.retain.should.equal(false);
+            config.getConfig().mqtt.retries.should.equal('2');
+            config.getConfig().mqtt.retryTime.should.equal('5');
+            config.getConfig().mqtt.keepalive.should.equal('0');
+            done();
+        });
+    });
+
+    describe('When the AMQP transport is started with environment variables', function() {
+        beforeEach(function() {
+            process.env.IOTA_AMQP_HOST = 'localhost';
+            process.env.IOTA_AMQP_PORT = '9090';
+            process.env.IOTA_AMQP_USERNAME = 'useramqp';
+            process.env.IOTA_AMQP_PASSWORD = 'passamqp';
+            process.env.IOTA_AMQP_EXCHANGE = 'xxx';
+            process.env.IOTA_AMQP_QUEUE = '0';
+            process.env.IOTA_AMQP_DURABLE = 'true';
+            process.env.IOTA_AMQP_RETRIES = '0';
+            process.env.IOTA_AMQP_RETRY_TIME = '5';
+        });
+
+        afterEach(function() {
+            delete process.env.IOTA_AMQP_HOST;
+            delete process.env.IOTA_AMQP_PORT;
+            delete process.env.IOTA_AMQP_USERNAME;
+            delete process.env.IOTA_AMQP_PASSWORD;
+            delete process.env.IOTA_AMQP_EXCHANGE;
+            delete process.env.IOTA_AMQP_QUEUE;
+            delete process.env.IOTA_AMQP_DURABLE;
+            delete process.env.IOTA_AMQP_RETRIES;
+            delete process.env.IOTA_AMQP_RETRY_TIME;
+        });
+
+        it('should load the AMQP environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().amqp.host.should.equal('localhost');
+            config.getConfig().amqp.port.should.equal('9090');
+            config.getConfig().amqp.username.should.equal('useramqp');
+            config.getConfig().amqp.password.should.equal('passamqp');
+            config.getConfig().amqp.exchange.should.equal('xxx');
+            config.getConfig().amqp.queue.should.equal('0');
+            config.getConfig().amqp.options.durable.should.equal(true);
+            config.getConfig().amqp.retries.should.equal('0');
+            config.getConfig().amqp.retryTime.should.equal('5');
+            done();
+        });
+    });
+
+    describe('When the HTTP transport is started with environment variables', function() {
+        beforeEach(function() {
+            sinon.stub(fs, 'statSync');
+            process.env.IOTA_HTTP_HOST = 'localhost';
+            process.env.IOTA_HTTP_PORT = '2222';
+            process.env.IOTA_HTTP_TIMEOUT = '5';
+            process.env.IOTA_HTTP_KEY = '/http/bbb/key.pem';
+            process.env.IOTA_HTTP_CERT = '/http/bbb/cert.pem';
+        });
+
+        afterEach(function() {
+            fs.statSync.restore();
+            delete process.env.IOTA_HTTP_HOST;
+            delete process.env.IOTA_HTTP_PORT;
+            delete process.env.IOTA_HTTP_TIMEOUT;
+            delete process.env.IOTA_HTTP_KEY;
+            delete process.env.IOTA_HTTP_CERT;
+        });
+
+        it('should load the HTTP environment variables in the internal configuration', function(done) {
+            config.setConfig(iotAgentConfig);
+            config.getConfig().http.host.should.equal('localhost');
+            config.getConfig().http.port.should.equal('2222');
+            config.getConfig().http.timeout.should.equal('5');
+            config.getConfig().http.key.should.equal('/http/bbb/key.pem');
+            config.getConfig().http.cert.should.equal('/http/bbb/cert.pem');
+            done();
+        });
+    });
+});

--- a/test/unit/ngsiv2/subscriptionRequests/configurationsMqttNotification.json
+++ b/test/unit/ngsiv2/subscriptionRequests/configurationsMqttNotification.json
@@ -1,0 +1,21 @@
+{
+  "subscriptionId": "51c0ac9ed714fb3b37d7d5a8",
+  "data": [
+    {
+      "id": "MQTT Device 1",
+      "type": "AnMQTTDevice",
+      "pollingInterval": {
+        "type": "string",
+        "value": "60",
+        "metadata": {
+        }
+      },
+      "publishInterval": {
+        "type": "number",
+        "value": "600",
+        "metadata": {
+        }
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/subscriptionRequests/configurationsMqttRequest.json
+++ b/test/unit/ngsiv2/subscriptionRequests/configurationsMqttRequest.json
@@ -1,0 +1,26 @@
+{
+  "subject":{
+    "entities": [
+      {
+        "id": "MQTT Device 1",
+        "type": "AnMQTTDevice"
+      }
+    ],
+    "condition":{
+      "attrs":[
+        "pollingInterval",
+        "publishInterval"
+      ]
+    }
+  },
+  "notification":{
+    "http":{
+      "url":"http://localhost:4061/notify"
+    },
+    "attrs":[
+      "pollingInterval",
+      "publishInterval"
+    ],
+    "attrsFormat": "normalized"
+  }
+}

--- a/test/unit/ngsiv2/ultralightCommands-test.js
+++ b/test/unit/ngsiv2/ultralightCommands-test.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ */
+
+const ulParser = require('../../../lib/ulParser');
+const should = require('should');
+
+describe('Ultralight 2.0 Parser: commands', function() {
+    describe('When a command execution with multiple parameters is parsed', function() {
+        it('should extract the deviceId, the command name, and the parameters', function() {
+            const result = ulParser.command('weatherStation167@ping|param1=1|param2=2');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            should.exist(result.deviceId);
+            result.deviceId.should.equal('weatherStation167');
+            should.exist(result.command);
+            result.command.should.equal('ping');
+            should.exist(result.params);
+            should.exist(result.params.param2);
+            result.params.param2.should.equal('2');
+        });
+    });
+    describe('When a command execution with no params and a value is parsed', function() {
+        it('should extract the deviceId, the command name, and the plain text of the value', function() {
+            const result = ulParser.command('weatherStation167@ping|theValue');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            should.exist(result.deviceId);
+            result.deviceId.should.equal('weatherStation167');
+            should.exist(result.command);
+            result.command.should.equal('ping');
+            should.exist(result.value);
+            result.value.should.equal('theValue');
+        });
+    });
+    describe('When a command result is parsed', function() {
+        describe('should extract the deviceId, the command name, and the result', function() {
+            it('should extract the deviceId, the command name, and the parameters', function() {
+                const result = ulParser.result('weatherStation167@ping|Ping ok');
+
+                should.exist(result);
+                (typeof result).should.equal('object');
+                should.exist(result.deviceId);
+                result.deviceId.should.equal('weatherStation167');
+                should.exist(result.command);
+                result.command.should.equal('ping');
+                should.exist(result.result);
+                result.result.should.equal('Ping ok');
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/ultralightMeasures-test.js
+++ b/test/unit/ngsiv2/ultralightMeasures-test.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ */
+
+const ulParser = require('../../../lib/ulParser');
+const should = require('should');
+
+describe('Ultralight 2.0 Parser: measures', function() {
+    describe('When a payload with a single measure is parsed', function() {
+        it('should return an array with a single object with just one attribute', function() {
+            const result = ulParser.parse('a|1');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            result.length.should.equal(1);
+            should.exist(result[0]);
+            should.exist(result[0].a);
+            result[0].a.should.equal('1');
+        });
+    });
+    describe('When a payload with a multiple measures is parsed', function() {
+        it('should return an array with a single object with multiple attributes', function() {
+            const result = ulParser.parse('c|7|b|18');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            result.length.should.equal(1);
+            should.exist(result[0]);
+            should.exist(result[0].c);
+            result[0].c.should.equal('7');
+            should.exist(result[0].b);
+            result[0].b.should.equal('18');
+        });
+    });
+    describe('When a payload with timestamp information is parsed', function() {
+        /* jshint sub:true */
+
+        it('should add a TimeInstant attribute to the array with the value', function() {
+            const result = ulParser.parse('2016-06-13T00:35:30Z|lle|100');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            result.length.should.equal(1);
+            should.exist(result[0]);
+            should.exist(result[0].TimeInstant);
+            result[0].TimeInstant.should.equal('2016-06-13T00:35:30Z');
+            should.exist(result[0].lle);
+            result[0].lle.should.equal('100');
+        });
+    });
+    describe('When a payload with an initial bar and multiple measures is parsed', function() {
+        it('should return an array with a single object with multiple attributes', function() {
+            const result = ulParser.parse('|c|7|b|18');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            result.length.should.equal(1);
+            should.exist(result[0]);
+            should.exist(result[0].c);
+            result[0].c.should.equal('7');
+            should.exist(result[0].b);
+            result[0].b.should.equal('18');
+        });
+    });
+
+    describe('When a payload with two groups of measures and one measure in each group is parsed', function() {
+        it('should return an array with two objects with just one attribute', function() {
+            const result = ulParser.parse('c|7#b|18');
+
+            should.exist(result);
+            (typeof result).should.equal('object');
+            result.length.should.equal(2);
+            should.exist(result[0]);
+            should.exist(result[0].c);
+            result[0].c.should.equal('7');
+            should.exist(result[1]);
+            should.exist(result[1].b);
+            result[1].b.should.equal('18');
+        });
+    });
+    describe('When a payload with multiple groups and measures is parsed', function() {
+        it('should return an array with the parsed groups and objects', function() {
+            const result = ulParser.parse('bat|75.0#tmp|16.25#ill|0.0#pos|43.46321/-3.80446');
+
+            should.exist(result);
+        });
+    });
+    describe('When a payload with command results is parsed', function() {
+        it('should return an array with the parsed groups and the command', function() {
+            const result = ulParser.parse('MQTT_2@ping|MADE_OK');
+
+            should.exist(result);
+            result.length.should.equal(1);
+            result[0].command.should.equal('ping');
+            result[0].deviceId.should.equal('MQTT_2');
+            result[0].value.should.equal('MADE_OK');
+        });
+    });
+    describe('When a payload with an empty measure is found: "a|10||"', function() {
+        it('should throw a PARSE_ERROR error', function() {
+            let result;
+            let error;
+
+            try {
+                result = ulParser.parse('a|10||');
+            } catch (e) {
+                error = e;
+            }
+
+            should.exist(error);
+            should.not.exist(result);
+            error.name.should.equal('PARSE_ERROR');
+        });
+    });
+    describe('When a payload with an empty measure group is found: "a|10|b|11##t|3"', function() {
+        it('should throw a PARSE_ERROR error', function() {
+            let result;
+            let error;
+
+            try {
+                result = ulParser.parse('a|10|b|11##t|3');
+            } catch (e) {
+                error = e;
+            }
+
+            should.exist(error);
+            should.not.exist(result);
+            error.name.should.equal('PARSE_ERROR');
+        });
+    });
+    describe('When an empty payload is parsed', function() {
+        it('should throw a PARSE_ERROR error', function() {
+            let result;
+            let error;
+
+            try {
+                result = ulParser.parse(undefined);
+            } catch (e) {
+                error = e;
+            }
+
+            should.exist(error);
+            should.not.exist(result);
+            error.name.should.equal('PARSE_ERROR');
+        });
+    });
+});


### PR DESCRIPTION
From NGSI-v1 https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/httpBinding-test.js#L192 updated to NGSI-v2

(Copy pasted from PR #493)

This PRs is made with the aim of add all cases cover by NGSI-v1 tests to NGSI-v2 tests. This comment is intended to provide track of the changes needed:

- [x] 1. Fix tests that are not matching on V2 
     - [x] commandsHttp-test.js ([1](https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/commandsHttp-test.js#L128) and [2](https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/commandsHttp-test.js#L169))
    - [x] [commandsMqtt-test.js](https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/commandsMqtt-test.js#L166)
    - [x] [httpBinding-test.js](https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/httpBinding-test.js#L192)

- [x] 2. Coppy tests that are NGSI agnostic to V2 folder
    - [x] startup-test.js
    - [x] ultralightMeasures-test.js
    - [x] ultralightCommands-test.js

- [x] 3. Implement missing tests in V2
    - [x] configurationsMqtt-test.js