### PR TITLE
patch for the iotagent issue 214 according to the author i changed the line

### DIFF
--- a/rpm/SOURCES/etc/init.d/iotaul
+++ b/rpm/SOURCES/etc/init.d/iotaul
@@ -6,7 +6,7 @@
 # description: Ultralight 2.0 IoT Agent for Telefonica's IoT Platform
 ### BEGIN INIT INFO
 # Provides: iotaul
-# Required-Start: $local_fs $syslog $network
+# Required-Start: $local_fs $syslog $network $iotamanager
 # Required-Stop: $local_fs $syslog
 # Default-Start:  345
 # Default-Stop: 90


### PR DESCRIPTION
Fixes #214 (Starting at boot failed /etc/init.d/iotaul)

Required-Start: $local_fs $syslog $network
by
Required-Start: $local_fs $syslog $network $iotamanager