### PR TITLE
Fix/content type response get http command

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+Fix: content-type response for get command to text/plain
 Fix: check access to active attribute of device before use it (twin of iota-json#576)
 Fix: processing configurations subscriptions in NGSIv2 (twin of iota-json#563)

--- a/lib/bindings/HTTPBindings.js
+++ b/lib/bindings/HTTPBindings.js
@@ -198,14 +198,16 @@ function returnCommands(req, res, next) {
     if (req.query && req.query.getCmd === '1') {
         iotAgentLib.commandQueue(req.device.service, req.device.subservice, req.deviceId, function (error, list) {
             if (error || !list || list.count === 0) {
+                res.set('Content-Type', 'text/plain');
                 res.status(200).send('');
             } else {
+                res.set('Content-Type', 'text/plain');
                 res.status(200).send(list.commands.map(parseCommand).reduce(concatCommand, ''));
-
                 process.nextTick(updateCommandStatus.bind(null, req.device, list.commands));
             }
         });
     } else {
+        res.set('Content-Type', 'text/plain');
         res.status(200).send('');
     }
 }


### PR DESCRIPTION
curl -i -X GET 'http://localhost:7896/iot/d?k=0a1hklrll9p8o2xzzdb3t5063&i=disp3&getCmd=1' -H 'accept: text/plain'
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: text/plain; charset=utf-8
Content-Length: 30
ETag: W/"1e-ROYkH00V8tEexx9OtEyBymleLGo"
Date: Wed, 21 Jul 2021 07:44:53 GMT
Connection: keep-alive

disp3@close|singlevaluecommand