### PR TITLE
Create config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -1,0 +1,19 @@
+{
+    "enabler": "IoT Agent for the Ultralight 2.0 protocol",
+    "chapter": "iotagents",
+    "academy": "iot-agents/idas",
+    "readthedocs": "fiware-iotagent-ul",
+    "helpdesk": "",
+    "coveralls": "https://coveralls.io/github/telefonicaid/iotagent-ul",
+    "github": ["telefonicaid/iotagent-ul"],
+    "dockerregistry": ["hub.docker.com"],
+    "docker": ["telefonicaiot/iotagent-ul"],
+    "email": "iot_support@tid.es",
+    "status": "full",
+    "compose": "",
+    "exclude": [""],
+    "stackexchange": ["fiware+iot"],
+    "unit-test": "",
+    "smoke-test": "",
+    "dockerfile": "https://github.com/telefonicaid/iotagent-ul/blob/master/docker/Dockerfile"
+}


### PR DESCRIPTION
The FIWARE Foundation need a simple JSON file available in a standard location in each repo to be able to continue to make FIWARE Releases and improve the degree of cross-product integration testing that can occur. This change has been agreed by the TSC and has been added to the contribution requirements.

Please suggest or amend values where known.