### PR TITLE
Remove preprocess stripping of explicitAttrs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 - FIX: provide device type to findConfiguration to achieve a better group match in getEffectiveApiKey (iota-node-lib#1155)
 - FIX: update polling when device is updated by adding endpoint (needs iota-node-lib >= 2.19) (twin for iota-json#602)
-- FIX: Remove preprocess stripping of explicitAttrs (#523)
+- FIX: Remove preprocess stripping of explicitAttrs (iotagent-node-lib#1151)
 - FIX: Add graceful shutdown listening to SIGINT (#524)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - FIX: provide device type to findConfiguration to achieve a better group match in getEffectiveApiKey (iota-node-lib#1155)
 - FIX: update polling when device is updated by adding endpoint (needs iota-node-lib >= 2.19) (twin for iota-json#602)
+- FIX: Remove preprocess stripping of explicitAttrs (#523)

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -118,20 +118,6 @@ function manageConfigurationRequest(apiKey, deviceId, device, objMessage) {
 /* eslint-disable-next-line no-unused-vars */
 function processMeasureGroup(device, apikey, previous, current, index) {
     const values = [];
-
-    function checkAttributes(k) {
-        if (device && device.active) {
-            for (let j = 0; j < device.active.length; j++) {
-                const objectId = 'object_id';
-                const name = 'name';
-                if (k === 'TimeInstant' || device.active[j][objectId] === k || device.active[j][name] === k) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     if (current.command) {
         previous.push(
             iotAgentLib.setCommandResult.bind(

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -146,25 +146,13 @@ function processMeasureGroup(device, apikey, previous, current, index) {
             )
         );
     } else {
-        if (device.explicitAttrs) {
-            for (const i in current) {
-                if (current.hasOwnProperty(i) && checkAttributes(i)) {
-                    values.push({
-                        name: i,
-                        type: guessType(i, device),
-                        value: current[i]
-                    });
-                }
-            }
-        } else {
-            for (const k in current) {
-                if (current.hasOwnProperty(k)) {
-                    values.push({
-                        name: k,
-                        type: guessType(k, device),
-                        value: current[k]
-                    });
-                }
+        for (const k in current) {
+            if (current.hasOwnProperty(k)) {
+                values.push({
+                    name: k,
+                    type: guessType(k, device),
+                    value: current[k]
+                });
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "git://github.com/jason-fox/iotagent-node-lib.git#feature/hidden",
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/jason-fox/iotagent-node-lib.git#feature/hidden",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.0",
     "mqtt": "3.0.0",
     "request": "2.88.0",


### PR DESCRIPTION
Instead of applying the `explicitAttr` filtering at the south port (i.e. to the measures being received by IOTA), move the filtering to the north port (i.e. at the point in which the CB update request is built). That way every measure/attribute will be available in calculations done by JELX expressions, but only the ones explicitly provisioned will pass to the CB.

see  https://github.com/telefonicaid/iotagent-node-lib/pull/1157#issuecomment-993711890

Part of https://github.com/telefonicaid/iotagent-node-lib/issues/1151