### PR TITLE
Add graceful shutdown

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - FIX: provide device type to findConfiguration to achieve a better group match in getEffectiveApiKey (iota-node-lib#1155)
 - FIX: update polling when device is updated by adding endpoint (needs iota-node-lib >= 2.19) (twin for iota-json#602)
+- FIX: Add graceful shutdown listening to SIGINT (#524)

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -476,6 +476,15 @@ npm run
 
 The following sections show the available options in detail.
 
+### Start
+
+Runs a local version of the IoT Agent
+
+```bash
+# Use git-bash on Windows
+npm start
+```
+
 ### Testing
 
 [Mocha](https://mochajs.org/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.

--- a/lib/iotagent-ul.js
+++ b/lib/iotagent-ul.js
@@ -229,7 +229,7 @@ function stop(callback) {
  *
  */
 function handleShutdown(signal) {
-    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    config.getLogger().info(context, 'Received %s, starting shutdown processs', signal);
     stop((err) => {
         if (err) {
             config.getLogger().error(context, err);

--- a/lib/iotagent-ul.js
+++ b/lib/iotagent-ul.js
@@ -224,5 +224,24 @@ function stop(callback) {
     );
 }
 
+/**
+ * Shuts down the IoT Agent in a graceful manner
+ *
+ */
+function handleShutdown(signal) {
+    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    stop((err) => {
+        if (err) {
+            config.getLogger().error(context, err);
+            return process.exit(1);
+        }
+        return process.exit(0);
+    });
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);
+process.on('SIGHUP', handleShutdown);
+
 exports.start = start;
 exports.stop = stop;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:text": "textlint 'README.md' 'docs/*.md' 'docs/**/*.md'",
     "prettier": "prettier --config .prettierrc.json --write '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "prettier:text": "prettier 'README.md' 'docs/*.md' 'docs/**/*.md' --no-config --tab-width 4 --print-width 120 --write --prose-wrap always",
+    "start": "node ./bin/iotagent-ul",
     "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit",
     "test:coverage": "nyc --reporter=lcov mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",


### PR DESCRIPTION
When a shutdown signal is sent, we need to do graceful shutdown out of Node.js and Express to avoid side effects
like finishing active requests before closing server, clean up resources, db connections etc.

see: https://stackfame.com/node-express-graceful-shutdown