### PR TITLE
Update Roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,4 +9,4 @@ This IoT Agent uses the [FIWARE IoT Agent Node.js Library](https://github.com/te
 This is why most of the functionalities of this component depend on the new features of the library itself. 
 
 For this reason, the roadmap of this component would be defined by the IoT Agent Node Library Roadmap that you can check
-[here](https://github.com/telefonicaid/iotagent-node-lib/blob/master/docs/roadmap.md)
+[here](https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/roadmap.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,44 +5,8 @@ This product is a FIWARE Generic Enabler. If you would like to learn about the o
 
 ### Introduction
 
-This section elaborates on proposed new features or tasks which are expected to be added to the product in the
-foreseeable future. There should be no assumption of a commitment to deliver these features on specific dates or in the
-order given. The development team will be doing their best to follow the proposed dates and priorities, but please bear
-in mind that plans to work on a given feature or task may be revised. All information is provided as general guidelines
-only, and this section may be revised to provide newer information at any time.
+This IoT Agent uses the [FIWARE IoT Agent Node.js Library](https://github.com/telefonicaid/iotagent-node-lib) framework. 
+This is why most of the functionalities of this component depend on the new features of the library itself. 
 
-Disclaimer:
-
--   This section has been last updated in March 2020. Please take into account its content could be obsolete.
--   Note we develop this software in Agile way, so development plan is continuously under review. Thus, this roadmap has
-    to be understood as rough plan of features to be done along time which is fully valid only at the time of writing
-    it. This roadmap has not be understood as a commitment on features and/or dates.
--   Some of the roadmap items may be implemented by external community developers, out of the scope of GE owners. Thus,
-    the moment in which these features will be finalized cannot be assured.
-
-### Short term
-
-The following list of features are planned to be addressed in the short term, and incorporated in a next release of the
-product:
-
--   Allow event dispatching in HA scenarios with MQTT via shared subscriptions
--   Support JSON objects and arrays as measure values in the southbound interface
-
-### Medium term
-
-The following list of features are planned to be addressed in the medium term, typically within the subsequent
-release(s) generated in the next 9 months after the next planned release:
-
--   Incremental introduccion of ECMAScript6 syntax (previous analysis of which sub-set of interesting aspect we want to
-    take)
--   Implementation of lazy attributes
--   Removal support for NGSIv1 (which currently is deprecated)
-
-### Long term
-
-The following list of features are proposals regarding the longer-term evolution of the product even though the
-development of these features has not yet been scheduled for a release in the near future. Please feel free to contact
-us if you wish to get involved in the implementation or influence the roadmap:
-
--   Analyze move transport implementations (HTTP, MQTT and AMQP) to iotagent-node-lib library (the agent could will only
-    implement the payload)
+For this reason, the roadmap of this component would be defined by the IoT Agent Node Library Roadmap that you can check
+[here](https://github.com/telefonicaid/iotagent-node-lib/blob/master/docs/roadmap.md)


### PR DESCRIPTION
After reviewing the Node-lib roadmap, it does not make so much sense to keep a separated roadmap since the functionalities are almost based on the library. 

For this reason, this PR change the agent roadmap in order to link to the iotagent-node-lib roadmap