### PR TITLE
Add flags to disable MQTT and AMQP

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Add flags to disable MQTT and AMQP (576)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Add flags to disable MQTT and AMQP (576)
+- Add IOTA_MQTT_DISABLED (mqtt.disabled) and IOTA_AMQP_DISABLED (amqp.disabled) flags to disable MQTT and AMQP (#576)
 - Set Nodejs 14 as minimum version in packages.json (effectively removing Nodev12 from supported versions)

--- a/config.js
+++ b/config.js
@@ -99,7 +99,12 @@ config.mqtt = {
     /**
      * Whether to use slashes at the beginning of topic when sending or not
      */
-    avoidLeadingSlash: false
+    avoidLeadingSlash: false,
+
+    /**
+     * Flag to disable the MQTT transport. (default is false).
+     */
+    disabled: false
 };
 
 config.amqp = {
@@ -109,7 +114,12 @@ config.amqp = {
     // password: 'guest',
     exchange: 'iota-exchange',
     queue: 'iotaqueue',
-    options: { durable: true }
+    options: { durable: true },
+
+    /**
+     * Flag to disable the AMQP transport. (default is false).
+     */
+    disabled: false
 };
 
 /**

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -256,6 +256,7 @@ The ones relating specific Ultralight 2.0 bindings are described in the followin
 | IOTA_MQTT_AVOID_LEADING_SLASH | mqtt.avoidLeadingSlash  |
 | IOTA_MQTT_CLEAN               | mqtt.clean              |
 | IOTA_MQTT_CLIENT_ID           | mqtt.clientId           |
+| IOTA_MQTT_DISABLED            | mqtt.disabled           |
 | IOTA_AMQP_HOST                | amqp.host               |
 | IOTA_AMQP_PORT                | amqp.port               |
 | IOTA_AMQP_USERNAME            | amqp.username           |
@@ -265,6 +266,7 @@ The ones relating specific Ultralight 2.0 bindings are described in the followin
 | IOTA_AMQP_DURABLE             | amqp.durable            |
 | IOTA_AMQP_RETRIES             | amqp.retries            |
 | IOTA_AMQP_RETRY_TIME          | amqp.retryTime          |
+| IOTA_AMQP_DISABLED            | amqp.disabled           |
 | IOTA_HTTP_HOST                | http.host               |
 | IOTA_HTTP_PORT                | http.port               |
 | IOTA_HTTP_TIMEOUT             | http.timeout            |

--- a/lib/bindings/AMQPBinding.js
+++ b/lib/bindings/AMQPBinding.js
@@ -118,15 +118,23 @@ function deviceUpdatingHandler(device, callback) {
 function start(callback) {
     let exchange;
     let queue;
+    const amqpConfig = config.getConfig().amqp;
 
-    if (config.getConfig() && config.getConfig().amqp && config.getConfig().amqp.exchange) {
-        exchange = config.getConfig().amqp.exchange;
+    if (!amqpConfig) {
+        return config.getLogger().error(context, 'Error AMPQ is not configured');
+    }
+    if (amqpConfig.disabled) {
+        return config.getLogger().warn(context, 'AMPQ is disabled');
+    }
+
+    if (amqpConfig.exchange) {
+        exchange = amqpConfig.exchange;
     } else {
         exchange = constants.AMQP_DEFAULT_EXCHANGE;
     }
 
-    if (config.getConfig() && config.getConfig().amqp && config.getConfig().amqp.queue) {
-        queue = config.getConfig().amqp.queue;
+    if (amqpConfig.queue) {
+        queue = amqpConfig.queue;
     } else {
         queue = constants.AMQP_DEFAULT_QUEUE;
     }
@@ -134,12 +142,10 @@ function start(callback) {
     let durable;
 
     if (
-        config.getConfig() &&
-        config.getConfig().amqp &&
-        config.getConfig().amqp.options &&
-        config.getConfig().amqp.options.durable
+        amqpConfig.options &&
+        amqpConfig.options.durable
     ) {
-        durable = config.getConfig().amqp.options.durable;
+        durable = amqpConfig.options.durable;
     } else {
         durable = constants.AMQP_DEFAULT_DURABLE;
     }
@@ -147,31 +153,29 @@ function start(callback) {
     let retries;
     let retryTime;
 
-    if (config.getConfig() && config.getConfig().amqp && config.getConfig().amqp.retries) {
-        retries = config.getConfig().amqp.retries;
+    if (amqpConfig.retries) {
+        retries = amqpConfig.retries;
     } else {
         retries = constants.AMQP_DEFAULT_RETRIES;
     }
-    if (config.getConfig() && config.getConfig().amqp && config.getConfig().amqp.retrytime) {
-        retryTime = config.getConfig().amqp.retryTime;
+    if (amqpConfig.retrytime) {
+        retryTime = amqpConfig.retryTime;
     } else {
         retryTime = constants.AMQP_DEFAULT_RETRY_TIME;
     }
 
     let uri = 'amqp://';
-    if (config.getConfig().amqp) {
-        if (config.getConfig().amqp.username && config.getConfig().amqp.password) {
-            uri += config.getConfig().amqp.username + ':' + config.getConfig().amqp.password + '@';
-        }
-        if (config.getConfig().amqp.host) {
-            uri += config.getConfig().amqp.host;
-            if (config.getConfig().amqp.port) {
-                uri += ':' + config.getConfig().amqp.port;
-            }
-        }
-    } else {
-        return config.getLogger().error(context, 'Error AMQP is not configured');
+    
+    if (amqpConfig.username && amqpConfig.password) {
+        uri += amqpConfig.username + ':' + amqpConfig.password + '@';
     }
+    if (amqpConfig.host) {
+        uri += amqpConfig.host;
+        if (amqpConfig.port) {
+            uri += ':' + amqpConfig.port;
+        }
+    }
+   
     let isConnecting = false;
     let numRetried = 0;
 

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -322,6 +322,9 @@ function start(callback) {
     if (!mqttConfig) {
         return config.getLogger().error(context, 'Error MQTT is not configured');
     }
+    if (mqttConfig.disabled) {
+        return config.getLogger().warn(context, 'MQTT is disabled');
+    }
 
     const rejectUnauthorized =
         typeof mqttConfig.rejectUnauthorized === 'boolean' ? mqttConfig.rejectUnauthorized : true;

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -274,6 +274,10 @@ function processEnvironmentVariables() {
         config.amqp.retryTime = process.env.IOTA_AMQP_RETRY_TIME;
     }
 
+    if (process.env.IOTA_AMQP_DISABLED && process.env.IOTA_AMQP_DISABLED.trim().toLowerCase() === 'true'){
+        config.amqp.disabled = true;
+    }
+
     if (anyIsSet(httpVariables)) {
         config.http = {};
     }

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -70,6 +70,7 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_AVOID_LEADING_SLASHES',
         'IOTA_MQTT_CLEAN',
         'IOTA_MQTT_CLIENT_ID',
+        'IOTA_MQTT_DISABLED',
         'IOTA_AMQP_HOST',
         'IOTA_AMQP_PORT',
         'IOTA_AMQP_USERNAME',
@@ -79,6 +80,7 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_DURABLE',
         'IOTA_AMQP_RETRIES',
         'IOTA_AMQP_RETRY_TIME',
+        'IOTA_AMQP_DISABLED'
         'IOTA_HTTP_HOST',
         'IOTA_HTTP_PORT',
         'IOTA_HTTP_TIMEOUT',
@@ -102,7 +104,8 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_KEEPALIVE',
         'IOTA_MQTT_AVOID_LEADING_SLASH',
         'IOTA_MQTT_CLEAN',
-        'IOTA_MQTT_CLIENT_ID'
+        'IOTA_MQTT_CLIENT_ID',
+        'IOTA_MQTT_DISABLED'
     ];
     const amqpVariables = [
         'IOTA_AMQP_HOST',
@@ -113,7 +116,8 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_QUEUE',
         'IOTA_AMQP_DURABLE',
         'IOTA_AMQP_RETRIES',
-        'IOTA_AMQP_RETRY_TIME'
+        'IOTA_AMQP_RETRY_TIME',
+        'IOTA_AMQP_DISABLED'
     ];
     const httpVariables = ['IOTA_HTTP_HOST', 'IOTA_HTTP_PORT', 'IOTA_HTTP_TIMEOUT', 'IOTA_HTTP_KEY', 'IOTA_HTTP_CERT'];
 
@@ -149,7 +153,7 @@ function processEnvironmentVariables() {
     }
 
     if (anyIsSet(mqttVariables)) {
-        config.mqtt = {};
+        config.mqtt = config.mqtt || {};
     }
 
     if (process.env.IOTA_MQTT_PROTOCOL) {
@@ -224,8 +228,13 @@ function processEnvironmentVariables() {
         config.mqtt.clientId = process.env.IOTA_MQTT_CLIENT_ID;
     }
 
+    if (process.env.IOTA_MQTT_DISABLED && process.env.IOTA_MQTT_DISABLED.trim().toLowerCase() === 'true'){
+        config.mqtt.disabled = true;
+    }
+
+
     if (anyIsSet(amqpVariables)) {
-        config.amqp = {};
+        config.amqp = config.amqp || {};
     }
 
     if (process.env.IOTA_AMQP_HOST) {

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -80,7 +80,7 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_DURABLE',
         'IOTA_AMQP_RETRIES',
         'IOTA_AMQP_RETRY_TIME',
-        'IOTA_AMQP_DISABLED'
+        'IOTA_AMQP_DISABLED',
         'IOTA_HTTP_HOST',
         'IOTA_HTTP_PORT',
         'IOTA_HTTP_TIMEOUT',

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -44,6 +44,7 @@ describe('Startup tests', function () {
             process.env.IOTA_MQTT_RETRIES = '2';
             process.env.IOTA_MQTT_RETRY_TIME = '5';
             process.env.IOTA_MQTT_KEEPALIVE = '0';
+            process.env.IOTA_MQTT_DISABLED = 'true';
         });
 
         afterEach(function () {
@@ -62,6 +63,7 @@ describe('Startup tests', function () {
             delete process.env.IOTA_MQTT_RETRIES;
             delete process.env.IOTA_MQTT_RETRY_TIME;
             delete process.env.IOTA_MQTT_KEEPALIVE;
+            delete process.env.IOTA_MQTT_DISABLED;
         });
 
         it('should load the MQTT environment variables in the internal configuration', function (done) {
@@ -79,6 +81,7 @@ describe('Startup tests', function () {
             config.getConfig().mqtt.retries.should.equal('2');
             config.getConfig().mqtt.retryTime.should.equal('5');
             config.getConfig().mqtt.keepalive.should.equal('0');
+            config.getConfig().mqtt.disabled.should.equal(true);
             done();
         });
     });
@@ -94,6 +97,7 @@ describe('Startup tests', function () {
             process.env.IOTA_AMQP_DURABLE = 'true';
             process.env.IOTA_AMQP_RETRIES = '0';
             process.env.IOTA_AMQP_RETRY_TIME = '5';
+            process.env.IOTA_AMQP_DISABLED = 'true';
         });
 
         afterEach(function () {
@@ -106,6 +110,7 @@ describe('Startup tests', function () {
             delete process.env.IOTA_AMQP_DURABLE;
             delete process.env.IOTA_AMQP_RETRIES;
             delete process.env.IOTA_AMQP_RETRY_TIME;
+            delete process.env.IOTA_AMQP_DISABLED;
         });
 
         it('should load the AMQP environment variables in the internal configuration', function (done) {
@@ -119,6 +124,7 @@ describe('Startup tests', function () {
             config.getConfig().amqp.options.durable.should.equal(true);
             config.getConfig().amqp.retries.should.equal('0');
             config.getConfig().amqp.retryTime.should.equal('5');
+            config.getConfig().amqp.disabled.should.equal(true);
             done();
         });
     });


### PR DESCRIPTION
This avoids unnecessary polling to connect to MQTT and AMQP if they are not there and keeps the logs nice and clean.
As a side-effect, startup is quicker too.

Just add the following config to your docker-compose.

```
      - IOTA_MQTT_DISABLED=true
      - IOTA_AMPQ_DISABLED=true
```

Evil twin of https://github.com/telefonicaid/iotagent-json/pull/685