### PR TITLE
use node lib refactor

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Align tests with iota-node-lib (v3.0) refactor

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "underscore": "1.12.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor"",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "underscore": "1.12.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor"",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "underscore": "1.12.1"

--- a/test/unit/ngsiv2/MQTT_commands_test.js
+++ b/test/unit/ngsiv2/MQTT_commands_test.js
@@ -147,7 +147,10 @@ describe('MQTT: Commands', function () {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartgondor')
                 .matchHeader('fiware-servicepath', '/gardens')
-                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json')
+                )
                 .reply(204);
         });
 

--- a/test/unit/ngsiv2/commandsAmqp-test.js
+++ b/test/unit/ngsiv2/commandsAmqp-test.js
@@ -174,7 +174,10 @@ describe('AMQP Transport binding: commands', function () {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartgondor')
                 .matchHeader('fiware-servicepath', '/gardens')
-                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json')
+                )
                 .reply(204);
         });
 

--- a/test/unit/ngsiv2/contextRequests/multipleMeasureProduction.json
+++ b/test/unit/ngsiv2/contextRequests/multipleMeasureProduction.json
@@ -1,36 +1,18 @@
 {
-	"batteryLevel": {
-		"type": "float",
-		"value": "75.0",
-		"metadata": {
-			"TimeInstant": {
-				"type": "DateTime",
-				"value": "2016-05-11T10:12:26.476659Z"
-			}
-		}
-	},
-	"TimeInstant": {
-		"type": "DateTime",
-		"value": "2016-05-11T10:12:26.476659Z"
-	},
-	"att_name": {
-		"type": "string",
-		"value": "value",
-		"metadata": {
-			"TimeInstant": {
-				"type": "DateTime",
-				"value": "2016-05-11T10:12:26.476659Z"
-			}
-		}
-	},
-	"coords": {
-		"type": "string",
-		"value": "WGS84",
-		"metadata": {
-			"TimeInstant": {
-				"type": "DateTime",
-				"value": "2016-05-11T10:12:26.476659Z"
-			}
-		}
-	}
+        "batteryLevel": {
+                "type": "float",
+                "value": "75.0"
+        },
+        "TimeInstant": {
+                "type": "DateTime",
+                "value": "2016-05-11T10:12:26.476659Z"
+        },
+        "att_name": {
+                "type": "string",
+                "value": "value"
+        },
+        "coords": {
+                "type": "string",
+                "value": "WGS84"
+        }
 }

--- a/test/unit/ngsiv2/contextRequests/singleMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/singleMeasure.json
@@ -2,5 +2,5 @@
   "temperature": {
        "value": "23",
        "type": "celsius"
-    }
+  }
 }

--- a/test/unit/ngsiv2/contextRequests/timeInstantDuplicated.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantDuplicated.json
@@ -1,13 +1,7 @@
 {
   "temperature": {
     "type": "float",
-    "value": "24.4",
-    "metadata": {
-      "TimeInstant": {
-        "type": "DateTime",
-        "value": "2016-09-26T12:19:26.476659Z"
-      }
-    }
+    "value": "24.4"
   },
   "TimeInstant": {
     "type": "DateTime",

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasures.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasures.json
@@ -1,23 +1,11 @@
 {
   "temperature": {
     "type": "float",
-    "value": "24.4",
-    "metadata": {
-      "TimeInstant": {
-        "type": "DateTime",
-        "value": "2020-06-14T12:19:26.476659Z"
-      }
-    }
+    "value": "24.4"
   },
   "humidity": {
     "type": "string",
-    "value": "32",
-    "metadata": {
-      "TimeInstant": {
-        "type": "DateTime",
-        "value": "2020-06-14T12:19:26.476659Z"
-      }
-    }
+    "value": "32"
   },
   "TimeInstant": {
     "type": "DateTime",

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasures2.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasures2.json
@@ -1,13 +1,7 @@
 {
   "temperature": {
     "type": "float",
-    "value": "24.4",
-    "metadata": {
-      "TimeInstant": {
-        "type": "DateTime",
-        "value": "2020-06-14T12:19:26.476659Z"
-      }
-    }
+    "value": "24.4"
   },
   "TimeInstant": {
     "type": "DateTime",

--- a/test/unit/ngsiv2/contextRequests/timestampMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/timestampMeasure.json
@@ -1,16 +1,10 @@
 {
-  "temperature":{
-    "type": "celsius",
-    "value": "23",
-    "metadata":{
-        "TimeInstant":{
-          "type": "DateTime",
-          "value": "20160530T162522304Z"
-        }
-      }
+    "temperature":{
+        "type": "celsius",
+        "value": "23"
     },
     "TimeInstant":{
-      "type": "DateTime",
-      "value": "20160530T162522304Z"
+        "type": "DateTime",
+        "value": "+002016-05-30T16:25:22"
     }
 }

--- a/test/unit/ngsiv2/contextRequests/updateStatus2.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus2.json
@@ -1,15 +1,10 @@
 {
-	"actionType": "update",
-	"entities": [{
-		"id": "Second MQTT Device",
-		"type": "AnMQTTDevice",
-		"PING_status": {
-			"type": "commandStatus",
-			"value": "OK"
-		},
-		"PING_info": {
-			"type": "commandResult",
-			"value": "1234567890"
-		}
-	}]
+    "PING_status": {
+        "type": "commandStatus",
+        "value": "OK"
+    },
+    "PING_info": {
+        "type": "commandResult",
+        "value": "1234567890"
+    }
 }

--- a/test/unit/ngsiv2/httpBindings-test.js
+++ b/test/unit/ngsiv2/httpBindings-test.js
@@ -646,8 +646,7 @@ describe('HTTP Transport binding: measures', function () {
             method: 'POST',
             qs: {
                 i: 'urn:x-iot:smartsantander:u7jcfa:fixed:t311',
-                k: '1234',
-                t: '2016-05-11T10:12:26.476659Z'
+                k: '1234'
             },
             headers: {
                 'Content-type': 'text/plain'
@@ -684,6 +683,7 @@ describe('HTTP Transport binding: measures', function () {
                     let attributes = 0;
 
                     for (const attribute in body) {
+                        // checks that all attributes has metadata
                         if (body.hasOwnProperty(attribute)) {
                             attributes++;
                             for (const metadata in body[attribute].metadata) {
@@ -699,7 +699,7 @@ describe('HTTP Transport binding: measures', function () {
                 .times(13)
                 .reply(204);
 
-            config.iota.timestamp = true;
+            config.iota.timestamp = true; // forces to add timestamp att and  metadata with timeinstant to all attributes
 
             nock('http://localhost:8082').post('/protocols').reply(200, {});
 


### PR DESCRIPTION
twin PR https://github.com/telefonicaid/iotagent-json/pull/700

PR to test agent with new iota node lib:
If timestamp is provided as measure then no metadata with timestamp is added to attributes.
Compression about timestamp is always checked in iotagent-node-lib, so always is uncompressed

iota-node-lib deb should be set to #master before merge